### PR TITLE
postMessage `Data` and `Vector` to a web worker, transferring buffer content

### DIFF
--- a/src/algorithm/proj.ts
+++ b/src/algorithm/proj.ts
@@ -23,6 +23,7 @@ export function reproject<T extends GeoArrowType>(
   toProjection: string,
 ): arrow.Data<T> | arrow.Vector<T> {
   const projectionFn = proj4(fromProjection, toProjection);
+  // Check if an arrow.Vector
   if ("data" in input) {
     return new arrow.Vector(
       input.data.map((data) => reprojectData(data, projectionFn)),

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * as child from "./child.js";
 export * as data from "./data.js";
 export * as type from "./type.js";
 export * as vector from "./vector.js";
+export * as worker from "./worker"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,4 @@ export * as child from "./child.js";
 export * as data from "./data.js";
 export * as type from "./type.js";
 export * as vector from "./vector.js";
-export * as worker from "./worker"
+export * as worker from "./worker";

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,0 +1,2 @@
+export { hardClone, isShared } from "./hard-clone.js";
+export { getTransferables } from "./transferable.js"

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,2 +1,3 @@
 export { hardClone, isShared } from "./hard-clone.js";
-export { getTransferables } from "./transferable.js"
+export { preparePostMessage } from "./transferable.js";
+export { rehydrateData, rehydrateVector } from "./rehydrate.js";

--- a/src/worker/rehydrate.ts
+++ b/src/worker/rehydrate.ts
@@ -1,4 +1,5 @@
 import * as arrow from "apache-arrow";
+import type { Buffers } from "apache-arrow/data";
 
 type PostMessageDataType = {
   __type: arrow.Type;
@@ -101,6 +102,15 @@ export function rehydrateData<T extends arrow.DataType>(
     ? rehydrateVector(data.dictionary)
     : undefined;
 
+  // data.buffers is a getter, so we need to recreate Buffers from the
+  // attributes on data
+  const buffers: Buffers<T> = {
+    [arrow.BufferType.OFFSET]: data.valueOffsets,
+    [arrow.BufferType.DATA]: data.values,
+    [arrow.BufferType.VALIDITY]: data.nullBitmap,
+    [arrow.BufferType.TYPE]: data.typeIds,
+  };
+
   // @ts-expect-error
   return new arrow.Data(
     // @ts-expect-error
@@ -109,7 +119,7 @@ export function rehydrateData<T extends arrow.DataType>(
     data.length,
     // @ts-expect-error
     data._nullCount,
-    data.buffers,
+    buffers,
     children,
     dictionary,
   );

--- a/src/worker/rehydrate.ts
+++ b/src/worker/rehydrate.ts
@@ -1,0 +1,33 @@
+import * as arrow from "apache-arrow";
+
+export function rehydrateType<T extends arrow.DataType>(type: T): T {
+  // TODO: type is a class and will get lost when structured cloned. We'll have
+  // to implement a JSON type representation
+  return type;
+}
+
+export function rehydrateData<T extends arrow.DataType>(
+  data: arrow.Data<T>,
+): arrow.Data<T> {
+  const children = data.children.map((childData) => rehydrateData(childData));
+  const dictionary = data.dictionary
+    ? rehydrateVector(data.dictionary)
+    : undefined;
+
+  return new arrow.Data(
+    rehydrateType(data.type),
+    data.offset,
+    data.length,
+    // @ts-expect-error
+    data._nullCount,
+    data.buffers,
+    children,
+    dictionary,
+  );
+}
+
+export function rehydrateVector<T extends arrow.DataType>(
+  vector: arrow.Vector<T>,
+): arrow.Vector<T> {
+  return new arrow.Vector(vector.data.map((data) => rehydrateData(data)));
+}

--- a/src/worker/rehydrate.ts
+++ b/src/worker/rehydrate.ts
@@ -1,9 +1,96 @@
 import * as arrow from "apache-arrow";
 
-export function rehydrateType<T extends arrow.DataType>(type: T): T {
-  // TODO: type is a class and will get lost when structured cloned. We'll have
-  // to implement a JSON type representation
-  return type;
+type PostMessageDataType = {
+  __type: arrow.Type;
+};
+type PostMessageField = {
+  type: PostMessageDataType;
+  name: string;
+  nullable: boolean;
+  metadata: Map<string, string>;
+};
+
+export function rehydrateType<T extends arrow.Type>(
+  type: arrow.DataType<T> & { __type: T },
+): arrow.DataType<T> {
+  switch (type.__type) {
+    case arrow.Type.Null:
+      return new arrow.Null() as arrow.DataType<T>;
+    case arrow.Type.Int:
+      // @ts-expect-error
+      return new arrow.Int(type.isSigned, type.bitWidth);
+    case arrow.Type.Float:
+      // @ts-expect-error
+      return new arrow.Float(type.precision);
+    case arrow.Type.Binary:
+      // @ts-expect-error
+      return new arrow.Binary();
+    case arrow.Type.Utf8:
+      // @ts-expect-error
+      return new arrow.Utf8();
+    case arrow.Type.Bool:
+      // @ts-expect-error
+      return new arrow.Bool();
+    case arrow.Type.Decimal:
+      // @ts-expect-error
+      return new arrow.Decimal(type.scale, type.precision, type.bitWidth);
+    case arrow.Type.Date:
+      // @ts-expect-error
+      return new arrow.Date_(type.unit);
+    // return new arrow.Date
+    case arrow.Type.Time:
+      // @ts-expect-error
+      return new arrow.Time(type.unit, type.bitWidth);
+    case arrow.Type.Timestamp:
+      // @ts-expect-error
+      return new arrow.Timestamp(type.unit, type.timezone);
+    case arrow.Type.Interval:
+      // @ts-expect-error
+      return new arrow.Interval(type.unit);
+    case arrow.Type.List: {
+      const children = type.children.map(rehydrateField);
+      if (children.length > 1) throw new Error("expected 1 field");
+      // @ts-expect-error
+      return new arrow.List(children[0]);
+    }
+    case arrow.Type.Struct: {
+      const children = type.children.map(rehydrateField);
+      // @ts-expect-error
+      return new arrow.Struct(children);
+    }
+    case arrow.Type.Union: {
+      const children = type.children.map(rehydrateField);
+      // @ts-expect-error
+      return new arrow.Union(type.mode, type.typeIds, children);
+    }
+    case arrow.Type.FixedSizeBinary:
+      // @ts-expect-error
+      return new arrow.FixedSizeBinary(type.byteWidth);
+    case arrow.Type.FixedSizeList: {
+      const children = type.children.map(rehydrateField);
+      if (children.length > 1) throw new Error("expected 1 field");
+      // @ts-expect-error
+      return new arrow.FixedSizeList(type.listSize, children[0]);
+    }
+    case arrow.Type.Map: {
+      const children = type.children.map(rehydrateField);
+      if (children.length > 1) throw new Error("expected 1 field");
+      const entries = children[0];
+      // @ts-expect-error
+      return new arrow.Map_(entries, type.keysSorted);
+    }
+    case arrow.Type.Duration:
+      // @ts-expect-error
+      return new arrow.Duration(type.unit);
+    default:
+      throw new Error(`unknown type ${type}`);
+  }
+}
+
+function rehydrateField(field: PostMessageField): arrow.Field {
+  // @ts-expect-error
+  const type = rehydrateType(field.type);
+  return new arrow.Field(field.name, type, field.nullable, field.metadata);
 }
 
 export function rehydrateData<T extends arrow.DataType>(
@@ -14,7 +101,9 @@ export function rehydrateData<T extends arrow.DataType>(
     ? rehydrateVector(data.dictionary)
     : undefined;
 
+  // @ts-expect-error
   return new arrow.Data(
+    // @ts-expect-error
     rehydrateType(data.type),
     data.offset,
     data.length,

--- a/src/worker/rehydrate.ts
+++ b/src/worker/rehydrate.ts
@@ -10,7 +10,7 @@ type PostMessageField = {
   metadata: Map<string, string>;
 };
 
-export function rehydrateType<T extends arrow.Type>(
+function rehydrateType<T extends arrow.Type>(
   type: arrow.DataType<T> & { __type: T },
 ): arrow.DataType<T> {
   switch (type.__type) {

--- a/src/worker/transferable.ts
+++ b/src/worker/transferable.ts
@@ -1,0 +1,42 @@
+import * as arrow from "apache-arrow";
+
+/**
+ * Get all transferable objects from this `Data` or `Vector`
+ */
+export function getTransferables<T extends arrow.DataType>(
+  input: arrow.Data<T> | arrow.Vector<T>,
+): ArrayBuffer[] {
+  // Check if `input` is an arrow.Vector
+  if ("data" in input) {
+    return input.data.flatMap((data) => getTransferables(data));
+  }
+
+  const arrayBuffers: ArrayBuffer[] = [];
+
+  // Handle children
+  for (const childData of input.children) {
+    arrayBuffers.push(...getTransferables(childData));
+  }
+
+  // Handle dictionary
+  if (input.dictionary !== undefined) {
+    arrayBuffers.push(...getTransferables(input.dictionary));
+  }
+
+  // We don't use a loop over these four to ensure accurate typing (well, typing
+  // doesn't seem to work on `DATA` and `TYPE`.)
+  if (input.buffers[arrow.BufferType.OFFSET] !== undefined) {
+    arrayBuffers.push(input.buffers[arrow.BufferType.OFFSET].buffer);
+  }
+  if (input.buffers[arrow.BufferType.DATA] !== undefined) {
+    arrayBuffers.push(input.buffers[arrow.BufferType.DATA].buffer);
+  }
+  if (input.buffers[arrow.BufferType.VALIDITY] !== undefined) {
+    arrayBuffers.push(input.buffers[arrow.BufferType.VALIDITY].buffer);
+  }
+  if (input.buffers[arrow.BufferType.TYPE] !== undefined) {
+    arrayBuffers.push(input.buffers[arrow.BufferType.TYPE].buffer);
+  }
+
+  return arrayBuffers;
+}

--- a/src/worker/transferable.ts
+++ b/src/worker/transferable.ts
@@ -2,46 +2,8 @@ import * as arrow from "apache-arrow";
 import { hardClone } from "./hard-clone";
 
 /**
- * Get all transferable objects from this `Data` or `Vector`
+ * Prepare a `Data` or `Vector` for a `postMessage` or `structuredClone`.
  */
-export function getTransferables<T extends arrow.DataType>(
-  input: arrow.Data<T> | arrow.Vector<T>,
-): ArrayBuffer[] {
-  // Check if `input` is an arrow.Vector
-  if ("data" in input) {
-    return input.data.flatMap((data) => getTransferables(data));
-  }
-
-  const arrayBuffers: ArrayBuffer[] = [];
-
-  // Handle children
-  for (const childData of input.children) {
-    arrayBuffers.push(...getTransferables(childData));
-  }
-
-  // Handle dictionary
-  if (input.dictionary !== undefined) {
-    arrayBuffers.push(...getTransferables(input.dictionary));
-  }
-
-  // We don't use a loop over these four to ensure accurate typing (well, typing
-  // doesn't seem to work on `DATA` and `TYPE`.)
-  if (input.buffers[arrow.BufferType.OFFSET] !== undefined) {
-    arrayBuffers.push(input.buffers[arrow.BufferType.OFFSET].buffer);
-  }
-  if (input.buffers[arrow.BufferType.DATA] !== undefined) {
-    arrayBuffers.push(input.buffers[arrow.BufferType.DATA].buffer);
-  }
-  if (input.buffers[arrow.BufferType.VALIDITY] !== undefined) {
-    arrayBuffers.push(input.buffers[arrow.BufferType.VALIDITY].buffer);
-  }
-  if (input.buffers[arrow.BufferType.TYPE] !== undefined) {
-    arrayBuffers.push(input.buffers[arrow.BufferType.TYPE].buffer);
-  }
-
-  return arrayBuffers;
-}
-
 export function preparePostMessage<T extends arrow.DataType>(
   input: arrow.Data<T>,
 ): [arrow.Data<T>, ArrayBuffer[]];

--- a/src/worker/transferable.ts
+++ b/src/worker/transferable.ts
@@ -1,4 +1,5 @@
 import * as arrow from "apache-arrow";
+import { hardClone } from "./hard-clone";
 
 /**
  * Get all transferable objects from this `Data` or `Vector`
@@ -39,4 +40,86 @@ export function getTransferables<T extends arrow.DataType>(
   }
 
   return arrayBuffers;
+}
+
+export function preparePostMessage<T extends arrow.DataType>(
+  input: arrow.Data<T>,
+): [arrow.Data<T>, ArrayBuffer[]];
+export function preparePostMessage<T extends arrow.DataType>(
+  input: arrow.Vector<T>,
+): [arrow.Vector<T>, ArrayBuffer[]];
+
+export function preparePostMessage<T extends arrow.DataType>(
+  input: arrow.Data<T> | arrow.Vector<T>,
+): [arrow.Data<T> | arrow.Vector<T>, ArrayBuffer[]] {
+  // Check if `input` is an arrow.Vector
+  if ("data" in input) {
+    const postMessageDatas: arrow.Data<T>[] = [];
+    const transferArrayBuffers: ArrayBuffer[] = [];
+    for (const data of input.data) {
+      const [postMessageData, arrayBuffers] = preparePostMessage(data);
+      postMessageDatas.push(postMessageData);
+      transferArrayBuffers.push(...arrayBuffers);
+    }
+    const vector = new arrow.Vector(postMessageDatas);
+    assignTypeIdOnType(vector.type);
+    return [vector, transferArrayBuffers];
+  }
+
+  // Force clone into non-shared backing ArrayBuffers
+  // Note: this only clones if necessary.
+  input = hardClone(input);
+
+  const transferArrayBuffers: ArrayBuffer[] = [];
+
+  // Handle children
+  for (let childIdx = 0; childIdx < input.children.length; childIdx++) {
+    const childData = input.children[childIdx];
+    const [postMessageData, arrayBuffers] = preparePostMessage(childData);
+    input.children[childIdx] = postMessageData;
+    transferArrayBuffers.push(...arrayBuffers);
+  }
+
+  // Handle dictionary
+  if (input.dictionary !== undefined) {
+    const [postMessageVector, arrayBuffers] = preparePostMessage(
+      input.dictionary,
+    );
+    input.dictionary = postMessageVector;
+    transferArrayBuffers.push(...arrayBuffers);
+  }
+
+  // Get references to the underlying buffers.
+
+  // We don't use a loop over these four to ensure accurate typing (well, typing
+  // doesn't seem to work on `DATA` and `TYPE`.)
+  if (input.buffers[arrow.BufferType.OFFSET] !== undefined) {
+    transferArrayBuffers.push(input.buffers[arrow.BufferType.OFFSET].buffer);
+  }
+  if (input.buffers[arrow.BufferType.DATA] !== undefined) {
+    transferArrayBuffers.push(input.buffers[arrow.BufferType.DATA].buffer);
+  }
+  if (input.buffers[arrow.BufferType.VALIDITY] !== undefined) {
+    transferArrayBuffers.push(input.buffers[arrow.BufferType.VALIDITY].buffer);
+  }
+  if (input.buffers[arrow.BufferType.TYPE] !== undefined) {
+    transferArrayBuffers.push(input.buffers[arrow.BufferType.TYPE].buffer);
+  }
+
+  assignTypeIdOnType(input.type);
+
+  return [input, transferArrayBuffers];
+}
+
+function assignTypeIdOnType<T extends arrow.Type>(
+  type: arrow.DataType<T>,
+): void {
+  // @ts-expect-error __type does not exist
+  type.__type = type.typeId;
+
+  if (type.children && type.children.length > 0) {
+    for (const child of type.children) {
+      assignTypeIdOnType(child.type);
+    }
+  }
 }

--- a/src/worker/transferable.ts
+++ b/src/worker/transferable.ts
@@ -6,13 +6,16 @@ import { hardClone } from "./hard-clone";
  */
 export function preparePostMessage<T extends arrow.DataType>(
   input: arrow.Data<T>,
+  forceClone?: boolean,
 ): [arrow.Data<T>, ArrayBuffer[]];
 export function preparePostMessage<T extends arrow.DataType>(
   input: arrow.Vector<T>,
+  forceClone?: boolean,
 ): [arrow.Vector<T>, ArrayBuffer[]];
 
 export function preparePostMessage<T extends arrow.DataType>(
   input: arrow.Data<T> | arrow.Vector<T>,
+  forceClone: boolean = false,
 ): [arrow.Data<T> | arrow.Vector<T>, ArrayBuffer[]] {
   // Check if `input` is an arrow.Vector
   if ("data" in input) {
@@ -29,8 +32,8 @@ export function preparePostMessage<T extends arrow.DataType>(
   }
 
   // Force clone into non-shared backing ArrayBuffers
-  // Note: this only clones if necessary.
-  input = hardClone(input);
+  // Note: this only clones if necessary, unless forceClone is `true`.
+  input = hardClone(input, forceClone);
 
   const transferArrayBuffers: ArrayBuffer[] = [];
 

--- a/tests/algorithm/owned-clone.test.ts
+++ b/tests/algorithm/owned-clone.test.ts
@@ -1,0 +1,26 @@
+import * as arrow from "apache-arrow";
+import { describe, expect, it } from "vitest";
+import { hardClone, isShared } from "../../src/worker/hard-clone";
+
+describe("hard clone", (t) => {
+  it("should hard clone array", () => {
+    const vector = arrow.makeVector(new Int32Array([1, 2, 3]));
+    const data = vector.data[0];
+    expect(isShared(data)).toBeFalsy();
+
+    const cloned = hardClone(data, true);
+    expect(isShared(cloned)).toBeFalsy();
+
+    // transfer the values buffer of the first data instance
+    structuredClone(data, { transfer: [data.values.buffer] });
+
+    expect(
+      data.values.buffer.byteLength,
+      "first buffer should have been neutered",
+    ).toStrictEqual(0);
+    expect(
+      cloned.values.buffer.byteLength,
+      "cloned buffer should not have been neutered (checks that they're two different backing buffers)",
+    ).toBeGreaterThan(0);
+  });
+});

--- a/tests/worker/transfer.test.ts
+++ b/tests/worker/transfer.test.ts
@@ -1,0 +1,41 @@
+import * as arrow from "apache-arrow";
+import { describe, expect, it } from "vitest";
+import { rehydrateData, preparePostMessage } from "../../src/worker";
+
+describe("transfer", (t) => {
+  it("should transfer correctly", () => {
+    const vector = arrow.makeVector(new Int32Array([1, 2, 3]));
+    const firstValue = vector.get(0);
+    const originalData = vector.data[0];
+    // console.log("original data", originalData);
+    // console.log(originalData.buffers);
+
+    const [preparedData, arrayBuffers] = preparePostMessage(originalData);
+    const receivedData = structuredClone(preparedData, {
+      transfer: arrayBuffers,
+    });
+    // console.log("received data");
+    // console.log(receivedData);
+
+    const rehydratedData = rehydrateData(receivedData);
+    // console.log("rehydrated data");
+    // console.log(rehydratedData);
+
+    expect(
+      rehydratedData instanceof arrow.Data,
+      "rehydrated data should be an instance of arrow.Data",
+    ).toBeTruthy();
+    expect(
+      rehydratedData.type instanceof arrow.DataType,
+      "rehydrated data's type should be an instance of arrow.DataType",
+    ).toBeTruthy();
+    expect(
+      originalData.values.buffer.byteLength,
+      "original values buffer should have been detached",
+    ).toStrictEqual(0);
+    expect(
+      new arrow.Vector([rehydratedData]).get(0),
+      "should match first value",
+    ).toStrictEqual(firstValue);
+  });
+});


### PR DESCRIPTION
### Change list

- Add `force` option onto `hardClone` to always clone, even if not necessary to be transferred. (defaults to `false`)
- `preparePostMessage` to:
  - hard clone backing `ArrayBuffers` if they're a view on a larger `ArrayBuffer`
  - Get a list of transferables
  - Assign `DataType.typeId` onto `__type` so that it can accurately be reconstructed on the other side of a `postMessage`
- `rehydrateData` and `rehydrateVector` to recreate full arrow classes from post messaged data
- Minimal test that transferring and rehydrating works! Using node's `structuredClone`