### PR TITLE
earcut worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "rollup -c rollup.config.js",
+    "build:rollup": "rollup -c rollup.config.js",
+    "build:workers": "node ./worker-build.mjs",
+    "build": "yarn build:rollup && yarn build:workers",
     "clean": "rimraf dist",
     "docs:build": "typedoc",
     "docs:publish": "gh-pages -d docs_build",
@@ -50,6 +52,7 @@
     "@types/node": "^20.9.3",
     "@types/proj4": "^2",
     "apache-arrow": "^14",
+    "esbuild": "^0.19.8",
     "gh-pages": "^6.1.0",
     "prettier": "^3.1.0",
     "rimraf": "^5.0.5",
@@ -66,6 +69,7 @@
   },
   "dependencies": {
     "@math.gl/polygon": "^4.0.0",
-    "proj4": "^2.9.2"
+    "proj4": "^2.9.2",
+    "threads": "^1.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoarrow/geoarrow-js",
-  "version": "0.2.0",
+  "version": "0.3.0-beta.1",
   "description": "TypeScript implementation of GeoArrow",
   "source": "src/index.ts",
   "umd:main": "dist/geoarrow.umd.js",

--- a/src/child.ts
+++ b/src/child.ts
@@ -2,7 +2,9 @@
  * Strongly typed accessors for children, since arrow.Data.children[] is untyped
  */
 
-import * as arrow from "apache-arrow";
+import { Data } from "apache-arrow/data";
+import { Vector } from "apache-arrow/vector";
+import { Float } from "apache-arrow/type";
 import {
   LineStringData,
   MultiLineStringData,
@@ -10,7 +12,7 @@ import {
   MultiPolygonData,
   PointData,
   PolygonData,
-} from "./data.js";
+} from "./data";
 import {
   LineStringVector,
   MultiLineStringVector,
@@ -18,19 +20,19 @@ import {
   MultiPolygonVector,
   PointVector,
   PolygonVector,
-} from "./vector.js";
+} from "./vector";
 
-export function getPointChild(input: PointData): arrow.Data<arrow.Float>;
-export function getPointChild(input: PointVector): arrow.Vector<arrow.Float>;
+export function getPointChild(input: PointData): Data<Float>;
+export function getPointChild(input: PointVector): Vector<Float>;
 
 export function getPointChild(
   input: PointData | PointVector,
-): arrow.Data<arrow.Float> | arrow.Vector<arrow.Float> {
+): Data<Float> | Vector<Float> {
   if ("data" in input) {
     return input.getChildAt(0)!;
   }
 
-  return input.children[0] as arrow.Data<arrow.Float>;
+  return input.children[0] as Data<Float>;
 }
 
 export function getLineStringChild(input: LineStringData): PointData;

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,4 +1,4 @@
-import * as arrow from "apache-arrow";
+import { Data } from "apache-arrow/data";
 import {
   Point,
   LineString,
@@ -12,14 +12,14 @@ import {
   isMultiPoint,
   isMultiLineString,
   isMultiPolygon,
-} from "./type.js";
+} from "./type";
 
-export type PointData = arrow.Data<Point>;
-export type LineStringData = arrow.Data<LineString>;
-export type PolygonData = arrow.Data<Polygon>;
-export type MultiPointData = arrow.Data<MultiPoint>;
-export type MultiLineStringData = arrow.Data<MultiLineString>;
-export type MultiPolygonData = arrow.Data<MultiPolygon>;
+export type PointData = Data<Point>;
+export type LineStringData = Data<LineString>;
+export type PolygonData = Data<Polygon>;
+export type MultiPointData = Data<MultiPoint>;
+export type MultiLineStringData = Data<MultiLineString>;
+export type MultiPolygonData = Data<MultiPolygon>;
 export type GeoArrowData =
   | PointData
   | LineStringData
@@ -28,28 +28,26 @@ export type GeoArrowData =
   | MultiLineStringData
   | MultiPolygonData;
 
-export function isPointData(data: arrow.Data): data is PointData {
+export function isPointData(data: Data): data is PointData {
   return isPoint(data.type);
 }
 
-export function isLineStringData(data: arrow.Data): data is LineStringData {
+export function isLineStringData(data: Data): data is LineStringData {
   return isLineString(data.type);
 }
 
-export function isPolygonData(data: arrow.Data): data is PolygonData {
+export function isPolygonData(data: Data): data is PolygonData {
   return isPolygon(data.type);
 }
 
-export function isMultiPointData(data: arrow.Data): data is MultiPointData {
+export function isMultiPointData(data: Data): data is MultiPointData {
   return isMultiPoint(data.type);
 }
 
-export function isMultiLineStringData(
-  data: arrow.Data,
-): data is MultiLineStringData {
+export function isMultiLineStringData(data: Data): data is MultiLineStringData {
   return isMultiLineString(data.type);
 }
 
-export function isMultiPolygonData(data: arrow.Data): data is MultiPolygonData {
+export function isMultiPolygonData(data: Data): data is MultiPolygonData {
   return isMultiPolygon(data.type);
 }

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,21 +1,27 @@
-import * as arrow from "apache-arrow";
+import {
+  Struct,
+  Float,
+  List,
+  FixedSizeList,
+  DataType,
+} from "apache-arrow/type";
 
 // Note: this apparently has to be arrow.Float and not arrow.Float64 to ensure
 // that recreating a data instance with arrow.makeData type checks using the
 // input's data type.
-export type InterleavedCoord = arrow.FixedSizeList<arrow.Float>;
-export type SeparatedCoord = arrow.Struct<{
-  x: arrow.Float;
-  y: arrow.Float;
+export type InterleavedCoord = FixedSizeList<Float>;
+export type SeparatedCoord = Struct<{
+  x: Float;
+  y: Float;
 }>;
 // TODO: support separated coords
 export type Coord = InterleavedCoord; // | SeparatedCoord;
 export type Point = Coord;
-export type LineString = arrow.List<Coord>;
-export type Polygon = arrow.List<arrow.List<Coord>>;
-export type MultiPoint = arrow.List<Coord>;
-export type MultiLineString = arrow.List<arrow.List<Coord>>;
-export type MultiPolygon = arrow.List<arrow.List<arrow.List<Coord>>>;
+export type LineString = List<Coord>;
+export type Polygon = List<List<Coord>>;
+export type MultiPoint = List<Coord>;
+export type MultiLineString = List<List<Coord>>;
+export type MultiPolygon = List<List<List<Coord>>>;
 export type GeoArrowType =
   | Point
   | LineString
@@ -25,22 +31,22 @@ export type GeoArrowType =
   | MultiPolygon;
 
 /** Check that the given type is a Point data type */
-export function isPoint(type: arrow.DataType): type is Point {
-  if (arrow.DataType.isFixedSizeList(type)) {
+export function isPoint(type: DataType): type is Point {
+  if (DataType.isFixedSizeList(type)) {
     // Check list size
     if (![2, 3, 4].includes(type.listSize)) {
       return false;
     }
 
     // Check child of FixedSizeList is floating type
-    if (!arrow.DataType.isFloat(type.children[0])) {
+    if (!DataType.isFloat(type.children[0])) {
       return false;
     }
 
     return true;
   }
 
-  if (arrow.DataType.isStruct(type)) {
+  if (DataType.isStruct(type)) {
     // Check number of children
     if (![2, 3, 4].includes(type.children.length)) {
       return false;
@@ -53,7 +59,7 @@ export function isPoint(type: arrow.DataType): type is Point {
       return false;
     }
 
-    if (!type.children.every((field) => arrow.DataType.isFloat(field))) {
+    if (!type.children.every((field) => DataType.isFloat(field))) {
       return false;
     }
 
@@ -63,9 +69,9 @@ export function isPoint(type: arrow.DataType): type is Point {
   return false;
 }
 
-export function isLineString(type: arrow.DataType): type is LineString {
+export function isLineString(type: DataType): type is LineString {
   // Check the outer type is a List
-  if (!arrow.DataType.isList(type)) {
+  if (!DataType.isList(type)) {
     return false;
   }
 
@@ -77,9 +83,9 @@ export function isLineString(type: arrow.DataType): type is LineString {
   return true;
 }
 
-export function isPolygon(type: arrow.DataType): type is Polygon {
+export function isPolygon(type: DataType): type is Polygon {
   // Check the outer vector is a List
-  if (!arrow.DataType.isList(type)) {
+  if (!DataType.isList(type)) {
     return false;
   }
 
@@ -91,9 +97,9 @@ export function isPolygon(type: arrow.DataType): type is Polygon {
   return true;
 }
 
-export function isMultiPoint(type: arrow.DataType): type is MultiPoint {
+export function isMultiPoint(type: DataType): type is MultiPoint {
   // Check the outer vector is a List
-  if (!arrow.DataType.isList(type)) {
+  if (!DataType.isList(type)) {
     return false;
   }
 
@@ -105,11 +111,9 @@ export function isMultiPoint(type: arrow.DataType): type is MultiPoint {
   return true;
 }
 
-export function isMultiLineString(
-  type: arrow.DataType,
-): type is MultiLineString {
+export function isMultiLineString(type: DataType): type is MultiLineString {
   // Check the outer vector is a List
-  if (!arrow.DataType.isList(type)) {
+  if (!DataType.isList(type)) {
     return false;
   }
 
@@ -121,9 +125,9 @@ export function isMultiLineString(
   return true;
 }
 
-export function isMultiPolygon(type: arrow.DataType): type is MultiPolygon {
+export function isMultiPolygon(type: DataType): type is MultiPolygon {
   // Check the outer vector is a List
-  if (!arrow.DataType.isList(type)) {
+  if (!DataType.isList(type)) {
     return false;
   }
 

--- a/src/vector.ts
+++ b/src/vector.ts
@@ -1,4 +1,4 @@
-import * as arrow from "apache-arrow";
+import { Vector } from "apache-arrow/vector";
 import {
   Point,
   LineString,
@@ -12,14 +12,14 @@ import {
   isMultiPoint,
   isMultiLineString,
   isMultiPolygon,
-} from "./type.js";
+} from "./type";
 
-export type PointVector = arrow.Vector<Point>;
-export type LineStringVector = arrow.Vector<LineString>;
-export type PolygonVector = arrow.Vector<Polygon>;
-export type MultiPointVector = arrow.Vector<MultiPoint>;
-export type MultiLineStringVector = arrow.Vector<MultiLineString>;
-export type MultiPolygonVector = arrow.Vector<MultiPolygon>;
+export type PointVector = Vector<Point>;
+export type LineStringVector = Vector<LineString>;
+export type PolygonVector = Vector<Polygon>;
+export type MultiPointVector = Vector<MultiPoint>;
+export type MultiLineStringVector = Vector<MultiLineString>;
+export type MultiPolygonVector = Vector<MultiPolygon>;
 export type GeoArrowVector =
   | PointVector
   | LineStringVector
@@ -28,34 +28,30 @@ export type GeoArrowVector =
   | MultiLineStringVector
   | MultiPolygonVector;
 
-export function isPointVector(vector: arrow.Vector): vector is PointVector {
+export function isPointVector(vector: Vector): vector is PointVector {
   return isPoint(vector.type);
 }
 
-export function isLineStringVector(
-  vector: arrow.Vector,
-): vector is LineStringVector {
+export function isLineStringVector(vector: Vector): vector is LineStringVector {
   return isLineString(vector.type);
 }
 
-export function isPolygonVector(vector: arrow.Vector): vector is PolygonVector {
+export function isPolygonVector(vector: Vector): vector is PolygonVector {
   return isPolygon(vector.type);
 }
 
-export function isMultiPointVector(
-  vector: arrow.Vector,
-): vector is MultiPointVector {
+export function isMultiPointVector(vector: Vector): vector is MultiPointVector {
   return isMultiPoint(vector.type);
 }
 
 export function isMultiLineStringVector(
-  vector: arrow.Vector,
+  vector: Vector,
 ): vector is MultiLineStringVector {
   return isMultiLineString(vector.type);
 }
 
 export function isMultiPolygonVector(
-  vector: arrow.Vector,
+  vector: Vector,
 ): vector is MultiPolygonVector {
   return isMultiPolygon(vector.type);
 }

--- a/src/worker-bundle/earcut.ts
+++ b/src/worker-bundle/earcut.ts
@@ -1,0 +1,20 @@
+import type { TransferDescriptor } from "threads";
+import { expose, Transfer } from "threads/worker";
+import { PolygonData } from "../data";
+import { earcut } from "../algorithm/earcut";
+
+function earcutWorker(polygonData: PolygonData): TransferDescriptor {
+  // NOTE!! Here we don't reconstruct a full arrow.Data instance to save on
+  // bundle size! We rely on the fact that nothing in the `earcut` function uses
+  // any class methods, which is not an ideal/easy assumption. Ideally we'll
+  // have functions in the future to validate geometry `Data` instances and
+  // construct Data and Vector instances without bringing in all of Arrow JS.
+
+  // const rehydratedData = rehydratePolygonData(polygonData);
+  const earcutTriangles = earcut(polygonData);
+  return Transfer(earcutTriangles, [earcutTriangles.buffer]);
+}
+
+export type EarcutOnWorker = typeof earcutWorker;
+
+expose(earcutWorker);

--- a/src/worker/rehydrate.ts
+++ b/src/worker/rehydrate.ts
@@ -1,15 +1,48 @@
-import * as arrow from "apache-arrow";
+import {
+  DataType,
+  Null,
+  Int,
+  Float,
+  Binary,
+  Utf8,
+  Bool,
+  Decimal,
+  Date_,
+  Time,
+  Timestamp,
+  Interval,
+  List,
+  Struct,
+  Union,
+  FixedSizeBinary,
+  FixedSizeList,
+  Map_,
+  Duration,
+} from "apache-arrow/type";
+import { BufferType, Type } from "apache-arrow/enum";
+import { Data } from "apache-arrow/data";
+import { Vector } from "apache-arrow/vector";
+import { Field } from "apache-arrow/schema";
 import type { Buffers } from "apache-arrow/data";
+import {
+  LineString,
+  Point,
+  Polygon,
+  MultiLineString,
+  MultiPoint,
+  MultiPolygon,
+} from "../type";
+import { PolygonData } from "../data";
 
 // Typedefs that include only the information kept from a structuredClone
-type PostMessageDataType = Pick<arrow.DataType, "children"> & {
-  __type: arrow.Type;
+type PostMessageDataType = Pick<DataType, "children"> & {
+  __type: Type;
 };
-type PostMessageField = Pick<arrow.Field, "name" | "nullable" | "metadata"> & {
+type PostMessageField = Pick<Field, "name" | "nullable" | "metadata"> & {
   type: PostMessageDataType;
 };
-type PostMessageData<T extends arrow.DataType> = Pick<
-  arrow.Data<T>,
+type PostMessageData<T extends DataType> = Pick<
+  Data<T>,
   | "type"
   | "length"
   | "offset"
@@ -20,15 +53,15 @@ type PostMessageData<T extends arrow.DataType> = Pick<
   | "typeIds"
   | "nullBitmap"
   | "valueOffsets"
->;
-type PostMessageVector<T extends arrow.DataType> = Pick<
-  arrow.Vector,
+> & {
+  type: PostMessageDataType;
+};
+type PostMessageVector<T extends DataType> = Pick<
+  Vector,
   "data" | "length" | "stride" | "numChildren"
 > & { type: PostMessageDataType };
 
-function rehydrateType<T extends arrow.Type>(
-  type: PostMessageDataType,
-): arrow.DataType<T> {
+function rehydrateType<T extends Type>(type: PostMessageDataType): DataType<T> {
   // Note: by default in Arrow JS, the `DataType` is a class with no identifying
   // attribute. Since a `structuredClone` is unable to maintain class
   // information, the result of `structuredClone(new arrow.Utf8())` is an empty
@@ -39,82 +72,82 @@ function rehydrateType<T extends arrow.Type>(
   // we can match on the `__type`, checking `arrow.Type` values, and
   // reconstitute a full `arrow.DataType` object.
   switch (type.__type) {
-    case arrow.Type.Null:
-      return new arrow.Null() as arrow.DataType<T>;
-    case arrow.Type.Int:
+    case Type.Null:
+      return new Null() as DataType<T>;
+    case Type.Int:
       // @ts-expect-error
-      return new arrow.Int(type.isSigned, type.bitWidth);
-    case arrow.Type.Float:
+      return new Int(type.isSigned, type.bitWidth);
+    case Type.Float:
       // @ts-expect-error
-      return new arrow.Float(type.precision);
-    case arrow.Type.Binary:
+      return new Float(type.precision);
+    case Type.Binary:
       // @ts-expect-error
-      return new arrow.Binary();
-    case arrow.Type.Utf8:
+      return new Binary();
+    case Type.Utf8:
       // @ts-expect-error
-      return new arrow.Utf8();
-    case arrow.Type.Bool:
+      return new Utf8();
+    case Type.Bool:
       // @ts-expect-error
-      return new arrow.Bool();
-    case arrow.Type.Decimal:
+      return new Bool();
+    case Type.Decimal:
       // @ts-expect-error
-      return new arrow.Decimal(type.scale, type.precision, type.bitWidth);
-    case arrow.Type.Date:
+      return new Decimal(type.scale, type.precision, type.bitWidth);
+    case Type.Date:
       // @ts-expect-error
-      return new arrow.Date_(type.unit);
-    // return new arrow.Date
-    case arrow.Type.Time:
+      return new Date_(type.unit);
+    // return new Date
+    case Type.Time:
       // @ts-expect-error
-      return new arrow.Time(type.unit, type.bitWidth);
-    case arrow.Type.Timestamp:
+      return new Time(type.unit, type.bitWidth);
+    case Type.Timestamp:
       // @ts-expect-error
-      return new arrow.Timestamp(type.unit, type.timezone);
-    case arrow.Type.Interval:
+      return new Timestamp(type.unit, type.timezone);
+    case Type.Interval:
       // @ts-expect-error
-      return new arrow.Interval(type.unit);
-    case arrow.Type.List: {
+      return new Interval(type.unit);
+    case Type.List: {
       const children = type.children.map(rehydrateField);
       if (children.length > 1) throw new Error("expected 1 field");
       // @ts-expect-error
-      return new arrow.List(children[0]);
+      return new List(children[0]);
     }
-    case arrow.Type.Struct: {
+    case Type.Struct: {
       const children = type.children.map(rehydrateField);
       // @ts-expect-error
-      return new arrow.Struct(children);
+      return new Struct(children);
     }
-    case arrow.Type.Union: {
+    case Type.Union: {
       const children = type.children.map(rehydrateField);
       // @ts-expect-error
-      return new arrow.Union(type.mode, type.typeIds, children);
+      return new Union(type.mode, type.typeIds, children);
     }
-    case arrow.Type.FixedSizeBinary:
+    case Type.FixedSizeBinary:
       // @ts-expect-error
-      return new arrow.FixedSizeBinary(type.byteWidth);
-    case arrow.Type.FixedSizeList: {
+      return new FixedSizeBinary(type.byteWidth);
+    case Type.FixedSizeList: {
       const children = type.children.map(rehydrateField);
       if (children.length > 1) throw new Error("expected 1 field");
       // @ts-expect-error
-      return new arrow.FixedSizeList(type.listSize, children[0]);
+      return new FixedSizeList(type.listSize, children[0]);
     }
-    case arrow.Type.Map: {
+    case Type.Map: {
       const children = type.children.map(rehydrateField);
       if (children.length > 1) throw new Error("expected 1 field");
       const entries = children[0];
       // @ts-expect-error
-      return new arrow.Map_(entries, type.keysSorted);
+      return new Map_(entries, type.keysSorted);
     }
-    case arrow.Type.Duration:
+    case Type.Duration:
       // @ts-expect-error
-      return new arrow.Duration(type.unit);
+      return new Duration(type.unit);
     default:
       throw new Error(`unknown type ${type}`);
   }
 }
 
-function rehydrateField(field: PostMessageField): arrow.Field {
+function rehydrateField(field: PostMessageField): Field {
   const type = rehydrateType(field.type);
-  return new arrow.Field(field.name, type, field.nullable, field.metadata);
+  return new Field(field.name, type, field.nullable, field.metadata);
 }
 
 /**
@@ -122,9 +155,10 @@ function rehydrateField(field: PostMessageField): arrow.Field {
  * `postMessage`'d. The `Data` **must** have been prepared with
  * `preparePostMessage` to be accurately recreated.
  */
-export function rehydrateData<T extends arrow.DataType>(
+export function rehydrateData<T extends DataType>(
   data: PostMessageData<T>,
-): arrow.Data<T> {
+): Data<T> {
+  // @ts-expect-error
   const children = data.children.map((childData) => rehydrateData(childData));
   const dictionary = data.dictionary
     ? rehydrateVector(data.dictionary)
@@ -133,15 +167,14 @@ export function rehydrateData<T extends arrow.DataType>(
   // data.buffers is a getter, so we need to recreate Buffers from the
   // attributes on data
   const buffers: Buffers<T> = {
-    [arrow.BufferType.OFFSET]: data.valueOffsets,
-    [arrow.BufferType.DATA]: data.values,
-    [arrow.BufferType.VALIDITY]: data.nullBitmap,
-    [arrow.BufferType.TYPE]: data.typeIds,
+    [BufferType.OFFSET]: data.valueOffsets,
+    [BufferType.DATA]: data.values,
+    [BufferType.VALIDITY]: data.nullBitmap,
+    [BufferType.TYPE]: data.typeIds,
   };
 
   // @ts-expect-error
   return new arrow.Data(
-    // @ts-expect-error
     rehydrateType(data.type),
     data.offset,
     data.length,
@@ -158,8 +191,142 @@ export function rehydrateData<T extends arrow.DataType>(
  * `postMessage`'d. The `Vector` **must** have been prepared with
  * `preparePostMessage` to be accurately recreated.
  */
-export function rehydrateVector<T extends arrow.DataType>(
+export function rehydrateVector<T extends DataType>(
   vector: PostMessageVector<T>,
-): arrow.Vector<T> {
-  return new arrow.Vector(vector.data.map((data) => rehydrateData(data)));
+): Vector<T> {
+  return new Vector(vector.data.map((data) => rehydrateData(data)));
+}
+
+export function rehydratePolygonData(
+  data: PostMessageData<Polygon>,
+): PolygonData {
+  if (!isPolygon(data.type)) {
+    throw new Error("Expected PolygonData");
+  }
+
+  // @ts-expect-error
+  // For now, we allow this, even though we never fully recreate the prototypes
+  // on the JS side.
+  return data;
+}
+
+// NOTE: these functions are copied from `type.ts` to work on __type
+
+/** Check that the given type is a Point data type */
+function isPoint(type: DataType): type is Point {
+  // @ts-expect-error
+  if (type.__type === Type.FixedSizeList) {
+    // Check list size
+    // @ts-expect-error
+    if (![2, 3, 4].includes(type.listSize)) {
+      return false;
+    }
+
+    // Check child of FixedSizeList is floating type
+    // @ts-expect-error
+    if (type.children[0].__type !== Type.Float) {
+      return false;
+    }
+
+    return true;
+  }
+
+  // @ts-expect-error
+  if (type.__type === Type.Struct) {
+    // Check number of children
+    if (![2, 3, 4].includes(type.children.length)) {
+      return false;
+    }
+
+    // Check that children have correct field names
+    if (
+      !type.children.every((field) => ["x", "y", "z", "m"].includes(field.name))
+    ) {
+      return false;
+    }
+
+    // @ts-expect-error
+    if (!type.children.every((field) => field.__type === Type.Float)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+function isLineString(type: DataType): type is LineString {
+  // Check the outer type is a List
+  // @ts-expect-error
+  if (type.__type !== Type.List) {
+    return false;
+  }
+
+  // Check the child is a point type
+  if (!isPoint(type.children[0].type)) {
+    return false;
+  }
+
+  return true;
+}
+
+function isPolygon(type: DataType): type is Polygon {
+  // Check the outer vector is a List
+  // @ts-expect-error
+  if (type.__type !== Type.List) {
+    return false;
+  }
+
+  // Check the child is a linestring vector
+  if (!isLineString(type.children[0].type)) {
+    return false;
+  }
+
+  return true;
+}
+
+function isMultiPoint(type: DataType): type is MultiPoint {
+  // Check the outer vector is a List
+  // @ts-expect-error
+  if (type.__type !== Type.List) {
+    return false;
+  }
+
+  // Check the child is a point vector
+  if (!isPoint(type.children[0].type)) {
+    return false;
+  }
+
+  return true;
+}
+
+function isMultiLineString(type: DataType): type is MultiLineString {
+  // Check the outer vector is a List
+  // @ts-expect-error
+  if (type.__type !== Type.List) {
+    return false;
+  }
+
+  // Check the child is a linestring vector
+  if (!isLineString(type.children[0].type)) {
+    return false;
+  }
+
+  return true;
+}
+
+function isMultiPolygon(type: DataType): type is MultiPolygon {
+  // Check the outer vector is a List
+  // @ts-expect-error
+  if (type.__type !== Type.List) {
+    return false;
+  }
+
+  // Check the child is a polygon vector
+  if (!isPolygon(type.children[0].type)) {
+    return false;
+  }
+
+  return true;
 }

--- a/src/worker/rehydrate.ts
+++ b/src/worker/rehydrate.ts
@@ -174,7 +174,7 @@ export function rehydrateData<T extends DataType>(
   };
 
   // @ts-expect-error
-  return new arrow.Data(
+  return new Data(
     rehydrateType(data.type),
     data.offset,
     data.length,

--- a/worker-build.mjs
+++ b/worker-build.mjs
@@ -1,0 +1,20 @@
+// worker-build.mjs
+import esbuild from "esbuild";
+
+esbuild.build({
+  entryPoints: ["./src/worker-bundle/earcut.ts"],
+  outfile: "dist/earcut-worker.js",
+  bundle: true,
+  minify: false,
+  target: ["esnext"],
+  format: "esm",
+});
+
+esbuild.build({
+  entryPoints: ["./src/worker-bundle/earcut.ts"],
+  outfile: "dist/earcut-worker.min.js",
+  bundle: true,
+  minify: true,
+  target: ["esnext"],
+  format: "esm",
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,9 +68,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/android-arm64@npm:0.19.8"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/android-arm@npm:0.19.7"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/android-arm@npm:0.19.8"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
@@ -82,9 +96,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-x64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/android-x64@npm:0.19.8"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-arm64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/darwin-arm64@npm:0.19.7"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/darwin-arm64@npm:0.19.8"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -96,9 +124,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-x64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/darwin-x64@npm:0.19.8"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-arm64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/freebsd-arm64@npm:0.19.7"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/freebsd-arm64@npm:0.19.8"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -110,9 +152,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-x64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/freebsd-x64@npm:0.19.8"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/linux-arm64@npm:0.19.7"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/linux-arm64@npm:0.19.8"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -124,9 +180,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/linux-arm@npm:0.19.8"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ia32@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/linux-ia32@npm:0.19.7"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/linux-ia32@npm:0.19.8"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
@@ -138,9 +208,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-loong64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/linux-loong64@npm:0.19.8"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-mips64el@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/linux-mips64el@npm:0.19.7"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/linux-mips64el@npm:0.19.8"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
@@ -152,9 +236,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ppc64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/linux-ppc64@npm:0.19.8"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-riscv64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/linux-riscv64@npm:0.19.7"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/linux-riscv64@npm:0.19.8"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
@@ -166,9 +264,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-s390x@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/linux-s390x@npm:0.19.8"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-x64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/linux-x64@npm:0.19.7"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/linux-x64@npm:0.19.8"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -180,9 +292,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/netbsd-x64@npm:0.19.8"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-x64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/openbsd-x64@npm:0.19.7"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/openbsd-x64@npm:0.19.8"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -194,9 +320,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/sunos-x64@npm:0.19.8"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-arm64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/win32-arm64@npm:0.19.7"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/win32-arm64@npm:0.19.8"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -208,9 +348,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/win32-ia32@npm:0.19.8"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/win32-x64@npm:0.19.7"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.19.8":
+  version: 0.19.8
+  resolution: "@esbuild/win32-x64@npm:0.19.8"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -225,12 +379,14 @@ __metadata:
     "@types/node": "npm:^20.9.3"
     "@types/proj4": "npm:^2"
     apache-arrow: "npm:^14"
+    esbuild: "npm:^0.19.8"
     gh-pages: "npm:^6.1.0"
     prettier: "npm:^3.1.0"
     proj4: "npm:^2.9.2"
     rimraf: "npm:^5.0.5"
     rollup: "npm:^4.1.5"
     rollup-plugin-dts: "npm:^6.1.0"
+    threads: "npm:^1.7.0"
     ts-node: "npm:^10.9.1"
     typedoc: "npm:^0.25.4"
     typescript: "npm:^5.2.2"
@@ -896,6 +1052,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"callsites@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "callsites@npm:3.1.0"
+  checksum: 072d17b6abb459c2ba96598918b55868af677154bec7e73d222ef95a8fdb9bbf7dae96a8421085cdad8cd190d86653b5b6dc55a4484f2e5b2e27d5e0c3fc15b3
+  languageName: node
+  linkType: hard
+
 "chai@npm:^4.3.10":
   version: 4.3.10
   resolution: "chai@npm:4.3.10"
@@ -1066,7 +1229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:^4.2.0, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -1229,10 +1392,94 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:^0.19.8":
+  version: 0.19.8
+  resolution: "esbuild@npm:0.19.8"
+  dependencies:
+    "@esbuild/android-arm": "npm:0.19.8"
+    "@esbuild/android-arm64": "npm:0.19.8"
+    "@esbuild/android-x64": "npm:0.19.8"
+    "@esbuild/darwin-arm64": "npm:0.19.8"
+    "@esbuild/darwin-x64": "npm:0.19.8"
+    "@esbuild/freebsd-arm64": "npm:0.19.8"
+    "@esbuild/freebsd-x64": "npm:0.19.8"
+    "@esbuild/linux-arm": "npm:0.19.8"
+    "@esbuild/linux-arm64": "npm:0.19.8"
+    "@esbuild/linux-ia32": "npm:0.19.8"
+    "@esbuild/linux-loong64": "npm:0.19.8"
+    "@esbuild/linux-mips64el": "npm:0.19.8"
+    "@esbuild/linux-ppc64": "npm:0.19.8"
+    "@esbuild/linux-riscv64": "npm:0.19.8"
+    "@esbuild/linux-s390x": "npm:0.19.8"
+    "@esbuild/linux-x64": "npm:0.19.8"
+    "@esbuild/netbsd-x64": "npm:0.19.8"
+    "@esbuild/openbsd-x64": "npm:0.19.8"
+    "@esbuild/sunos-x64": "npm:0.19.8"
+    "@esbuild/win32-arm64": "npm:0.19.8"
+    "@esbuild/win32-ia32": "npm:0.19.8"
+    "@esbuild/win32-x64": "npm:0.19.8"
+  dependenciesMeta:
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 8c440db4689948626dbc4122a03575c378e86e630e5de3789464504cd474bf3a1fd7c9402ed79eb8aa2f83e5cfd75872c8607d6255a05e540065b42750e89afe
+  languageName: node
+  linkType: hard
+
 "escape-string-regexp@npm:^1.0.2, escape-string-regexp@npm:^1.0.5":
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
   checksum: 6092fda75c63b110c706b6a9bfde8a612ad595b628f0bd2147eea1d3406723020810e591effc7db1da91d80a71a737a313567c5abb3813e8d9c71f4aa595b410
+  languageName: node
+  linkType: hard
+
+"esm@npm:^3.2.25":
+  version: 3.2.25
+  resolution: "esm@npm:3.2.25"
+  checksum: ee96b8202b76dd1841c55e8a066608d6f0ae0333012be5c77829ccadcd21114283b4d7bf9ac1b8c09853258829c7843e9c6d7e0594acbc5e813cb37d82728d4b
   languageName: node
   linkType: hard
 
@@ -1568,6 +1815,13 @@ __metadata:
   version: 1.0.1
   resolution: "is-lambda@npm:1.0.1"
   checksum: 93a32f01940220532e5948538699ad610d5924ac86093fcee83022252b363eb0cc99ba53ab084a04e4fb62bf7b5731f55496257a4c38adf87af9c4d352c71c35
+  languageName: node
+  linkType: hard
+
+"is-observable@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "is-observable@npm:2.1.0"
+  checksum: 93b0e0f9b115ef4b5f0523f4930667a7809a42e9cf1b23a444f8a9c15f72b9c1729b2a4691d55a5c479a05eafd5dda9b51ed1b65336d56027b7989ecb8ef51bf
   languageName: node
   linkType: hard
 
@@ -1935,6 +2189,13 @@ __metadata:
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
+  languageName: node
+  linkType: hard
+
+"observable-fns@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "observable-fns@npm:0.6.1"
+  checksum: 6b97d685db359196b081e152af2b37859dcc2d0a8d21ba9772cae79240af63b903604c9e30e0295fb9d89fcfd7eb93b8338b89da22fbee40589d367644185eff
   languageName: node
   linkType: hard
 
@@ -2605,6 +2866,31 @@ __metadata:
   bin:
     terser: bin/terser
   checksum: bd7ba6bfef58f8c179592894923c8c933d980e17287d3f2a9927550be853d1601beebb724cf015929599b32945641c44f9c3db8dd242c7933af3830bcb853510
+  languageName: node
+  linkType: hard
+
+"threads@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "threads@npm:1.7.0"
+  dependencies:
+    callsites: "npm:^3.1.0"
+    debug: "npm:^4.2.0"
+    is-observable: "npm:^2.1.0"
+    observable-fns: "npm:^0.6.1"
+    tiny-worker: "npm:>= 2"
+  dependenciesMeta:
+    tiny-worker:
+      optional: true
+  checksum: e4cefeac67a9d3609d95b2c02e9f868e152dec210179073810a64084256fad2e0795d778ec69a06eb5bd4a76185af689ca0348f84d44d758d6736edbfa841116
+  languageName: node
+  linkType: hard
+
+"tiny-worker@npm:>= 2":
+  version: 2.3.0
+  resolution: "tiny-worker@npm:2.3.0"
+  dependencies:
+    esm: "npm:^3.2.25"
+  checksum: 5643f030984a38a3c1b20fde0af93cf5a19d246cdf8ebaeb85e7a076115c1f976363ac9f8611fca507f6a6ae350b01f0a42c2ae522e75f1719f36779e93b8618
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Change list

- Add build process via esbuild to generate worker
- Change arrow imports to be _from the file_ that exports them, not the top level. I found that this **significantly** reduced bundle size.

In particular, comparing the tree shaking output of 
```ts
import { BufferType, Type } from "apache-arrow/enum";
import { Data } from "apache-arrow/data";
import { Vector } from "apache-arrow/vector";
import { Field } from "apache-arrow/schema";
``` 

with 

```ts
import { BufferType, Type } from "apache-arrow";
import { Data } from "apache-arrow";
import { Vector } from "apache-arrow";
import { Field } from "apache-arrow";
```

Just that one change (from the latter to the former) reduced the minified earcut worker from 205kb to 74kb. 

- Remove full data type reconstruction from the earcut worker. Eliminating imports of `DataType` and `Field` classes and related functionality reduced bundle size from 74kb to 15kb!!
- Note that all of these bundle sizes are uncompressed!! The brotli-compressed final bundle drops to just 6kb!! 🤯 
- I also published 0.3.0-beta.1 from this branch





