### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,13 @@ Refer to the [`worker` namespace](https://geoarrow.github.io/geoarrow-js/modules
 ```ts
 import * as arrow from "apache-arrow";
 import {
+  worker
+} from "@geoarrow/geoarrow-js";
+
+const {
   preparePostMessage,
-  rehydrateVector,
-} from "@geoarrow/geoarrow-js/worker";
+  rehydrateVector
+} = worker;
 
 const originalVector = arrow.makeVector(new Int32Array([1, 2, 3]));
 const [preparedVector, arrayBuffers] = preparePostMessage(originalVector);

--- a/README.md
+++ b/README.md
@@ -33,23 +33,16 @@ Refer to the [`worker` namespace](https://geoarrow.github.io/geoarrow-js/modules
 
 ```ts
 import * as arrow from "apache-arrow";
-import {
-  worker
-} from "@geoarrow/geoarrow-js";
-
-const {
-  preparePostMessage,
-  rehydrateVector
-} = worker;
+import { worker } from "@geoarrow/geoarrow-js";
 
 const originalVector = arrow.makeVector(new Int32Array([1, 2, 3]));
-const [preparedVector, arrayBuffers] = preparePostMessage(originalVector);
+const [preparedVector, arrayBuffers] = worker.preparePostMessage(originalVector);
 
 // Here we use structuredClone to simulate a postMessage but on the main thread
 const receivedVector = structuredClone(preparedVector, {
   transfer: arrayBuffers,
 });
-const rehydratedVector = rehydrateVector(receivedVector);
+const rehydratedVector = worker.rehydrateVector(receivedVector);
 ```
 
 ## Ecosystem


### PR DESCRIPTION
The example snippet in the README shows the `@geoarrow/geoarrow-js/worker` entrypoint but the rollup and `src/index.ts` config show a `worker` named import instead. This updates the README to reflect that difference.