### PR TITLE
Fix polygon ringoffset

### DIFF
--- a/src/io/wkb.ts
+++ b/src/io/wkb.ts
@@ -17,7 +17,6 @@ import { assert, assertFalse } from "../algorithm/utils/assert";
 import { FixedSizeList, Float64, List } from "apache-arrow/type";
 import { Field } from "apache-arrow/schema";
 
-
 export enum WKBType {
   Point,
   LineString,
@@ -38,7 +37,6 @@ export function parseWkb(
   dim: number,
 ): GeoArrowData {
   const parsedGeometries: BinaryGeometry[] = [];
-
 
   for (const item of iterBinary(data)) {
     if (item === null) {
@@ -205,9 +203,9 @@ function repackPolygons(
       ringIdx++
     ) {
       ringOffsets[ringOffset + 1] =
-        (geom.primitivePolygonIndices.value[ringOffset + 1] -
-          geom.primitivePolygonIndices.value[ringOffset]) /
-        geom.positions.size;
+        ringOffsets[ringOffset] +
+        (geom.primitivePolygonIndices.value[ringIdx + 1] -
+          geom.primitivePolygonIndices.value[ringIdx]);
       ringOffset += 1;
     }
 


### PR DESCRIPTION
Testing out `parseWkb` in spatial-access-measures I saw that the`repackPolygons` function was returning bad data:

![image](https://github.com/user-attachments/assets/57b60ee0-c5ef-40ed-a654-bca3bb9c1bf7)

Fixing polygon ringoffset results in correct filled polygons

![image](https://github.com/user-attachments/assets/f9c7c12c-4ee0-4eb0-bda7-4ea81856d67c)

 