### PR TITLE
Consolidate apache arrow imports

### DIFF
--- a/src/child.ts
+++ b/src/child.ts
@@ -2,8 +2,7 @@
  * Strongly typed accessors for children, since arrow.Data.children[] is untyped
  */
 
-import { Data, Vector } from "apache-arrow";
-import { Float } from "apache-arrow/type";
+import { Data, Vector, type Float } from "apache-arrow";
 import {
   LineStringData,
   MultiLineStringData,

--- a/src/child.ts
+++ b/src/child.ts
@@ -2,8 +2,7 @@
  * Strongly typed accessors for children, since arrow.Data.children[] is untyped
  */
 
-import { Data } from "apache-arrow/data";
-import { Vector } from "apache-arrow/vector";
+import { Data, Vector } from "apache-arrow";
 import { Float } from "apache-arrow/type";
 import {
   LineStringData,

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,4 +1,4 @@
-import { Data } from "apache-arrow/data";
+import { Data } from "apache-arrow";
 import {
   WKB,
   Point,

--- a/src/io/wkb.ts
+++ b/src/io/wkb.ts
@@ -1,5 +1,4 @@
-import { makeData, Field } from "apache-arrow";
-import { FixedSizeList, Float64, List } from "apache-arrow/type";
+import { makeData, Field, FixedSizeList, Float64, List } from "apache-arrow";
 import {
   GeoArrowData,
   LineStringData,

--- a/src/io/wkb.ts
+++ b/src/io/wkb.ts
@@ -1,4 +1,5 @@
-import { makeData } from "apache-arrow/data";
+import { makeData, Field } from "apache-arrow";
+import { FixedSizeList, Float64, List } from "apache-arrow/type";
 import {
   GeoArrowData,
   LineStringData,
@@ -14,9 +15,6 @@ import type {
   BinaryPolygonGeometry,
 } from "@loaders.gl/schema";
 import { assert, assertFalse } from "../algorithm/utils/assert";
-import { FixedSizeList, Float64, List } from "apache-arrow/type";
-import { Field } from "apache-arrow/schema";
-
 
 export enum WKBType {
   Point,
@@ -38,7 +36,6 @@ export function parseWkb(
   dim: number,
 ): GeoArrowData {
   const parsedGeometries: BinaryGeometry[] = [];
-
 
   for (const item of iterBinary(data)) {
     if (item === null) {

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,11 +1,11 @@
 import {
-  Binary,
-  Struct,
-  Float,
-  List,
-  FixedSizeList,
+  type Binary,
+  type Struct,
+  type Float,
+  type List,
+  type FixedSizeList,
   DataType,
-} from "apache-arrow/type";
+} from "apache-arrow";
 
 // Note: this apparently has to be arrow.Float and not arrow.Float64 to ensure
 // that recreating a data instance with arrow.makeData type checks using the

--- a/src/vector.ts
+++ b/src/vector.ts
@@ -1,4 +1,4 @@
-import { Vector } from "apache-arrow/vector";
+import { Vector } from "apache-arrow";
 import {
   Point,
   LineString,

--- a/src/worker/hard-clone.ts
+++ b/src/worker/hard-clone.ts
@@ -1,7 +1,4 @@
-import { Data } from "apache-arrow/data";
-import { DataType } from "apache-arrow/type";
-import { Vector } from "apache-arrow/vector";
-import { BufferType } from "apache-arrow/enum";
+import { Data, DataType, Vector, BufferType } from "apache-arrow";
 import type { Buffers } from "apache-arrow/data";
 
 type TypedArray =

--- a/src/worker/rehydrate.ts
+++ b/src/worker/rehydrate.ts
@@ -1,5 +1,9 @@
 import {
-  DataType,
+  BufferType,
+  Type,
+  Data,
+  Vector,
+  Field,
   Null,
   Int,
   Float,
@@ -18,8 +22,8 @@ import {
   FixedSizeList,
   Map_,
   Duration,
-} from "apache-arrow/type";
-import { BufferType, Type, Data, Vector, Field } from "apache-arrow";
+  type DataType,
+} from "apache-arrow";
 import type { Buffers } from "apache-arrow/data";
 import { Polygon, isPolygon } from "../type";
 import { PolygonData } from "../data";

--- a/src/worker/rehydrate.ts
+++ b/src/worker/rehydrate.ts
@@ -19,10 +19,7 @@ import {
   Map_,
   Duration,
 } from "apache-arrow/type";
-import { BufferType, Type } from "apache-arrow/enum";
-import { Data } from "apache-arrow/data";
-import { Vector } from "apache-arrow/vector";
-import { Field } from "apache-arrow/schema";
+import { BufferType, Type, Data, Vector, Field } from "apache-arrow";
 import type { Buffers } from "apache-arrow/data";
 import { Polygon, isPolygon } from "../type";
 import { PolygonData } from "../data";

--- a/src/worker/transferable.ts
+++ b/src/worker/transferable.ts
@@ -59,19 +59,16 @@ export function preparePostMessage<T extends DataType>(
   // We don't use a loop over these four to ensure accurate typing (well, typing
   // doesn't seem to work on `DATA` and `TYPE`.)
   if (input.buffers[BufferType.OFFSET] !== undefined) {
-    // @ts-expect-error
     transferArrayBuffers.push(input.buffers[BufferType.OFFSET].buffer);
   }
 
   if (input.buffers[BufferType.DATA] !== undefined) {
-    // @ts-expect-error
     transferArrayBuffers.push(input.buffers[BufferType.DATA].buffer);
   }
   if (input.buffers[BufferType.VALIDITY] !== undefined) {
     transferArrayBuffers.push(input.buffers[BufferType.VALIDITY].buffer);
   }
   if (input.buffers[BufferType.TYPE] !== undefined) {
-    // @ts-expect-error
     transferArrayBuffers.push(input.buffers[BufferType.TYPE].buffer);
   }
 

--- a/src/worker/transferable.ts
+++ b/src/worker/transferable.ts
@@ -1,7 +1,5 @@
+import { Data, Vector, BufferType } from "apache-arrow";
 import { DataType } from "apache-arrow/type";
-import { BufferType } from "apache-arrow/enum";
-import { Data } from "apache-arrow/data";
-import { Vector } from "apache-arrow/vector";
 import { hardClone } from "./hard-clone";
 
 /**
@@ -61,15 +59,19 @@ export function preparePostMessage<T extends DataType>(
   // We don't use a loop over these four to ensure accurate typing (well, typing
   // doesn't seem to work on `DATA` and `TYPE`.)
   if (input.buffers[BufferType.OFFSET] !== undefined) {
+    // @ts-expect-error
     transferArrayBuffers.push(input.buffers[BufferType.OFFSET].buffer);
   }
+
   if (input.buffers[BufferType.DATA] !== undefined) {
+    // @ts-expect-error
     transferArrayBuffers.push(input.buffers[BufferType.DATA].buffer);
   }
   if (input.buffers[BufferType.VALIDITY] !== undefined) {
     transferArrayBuffers.push(input.buffers[BufferType.VALIDITY].buffer);
   }
   if (input.buffers[BufferType.TYPE] !== undefined) {
+    // @ts-expect-error
     transferArrayBuffers.push(input.buffers[BufferType.TYPE].buffer);
   }
 

--- a/src/worker/transferable.ts
+++ b/src/worker/transferable.ts
@@ -1,5 +1,4 @@
-import { Data, Vector, BufferType } from "apache-arrow";
-import { DataType } from "apache-arrow/type";
+import { Data, Vector, BufferType, type DataType } from "apache-arrow";
 import { hardClone } from "./hard-clone";
 
 /**


### PR DESCRIPTION
Importing apache-arrow from root level outputs a lighter (~100kb) bundle. The assets built with subpaths imports included some of the classes and utilities (`Vector`, `Data`.. - which will lead to a problem with `isInstanceof`) that are supposed to come from apache-arrow. 

I still think the problem should not be subpath import itself but might be the circular dependencies the subpath modules have - Rollup is trying to resolve the circular dependency by partially importing the package and then embedding the rest of it to the built asset to get out of circular dependency? - I am honestly not sure what exactly is happening here, but importing from root level seems to solve the issue. 