### PR TITLE
feat: Worker build improvements for earcut worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,13 @@
   "module": "dist/geoarrow.es.mjs",
   "main": "dist/geoarrow.cjs",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "require": "./dist/geoarrow.cjs",
-    "default": "./dist/geoarrow.es.mjs"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/geoarrow.cjs",
+      "default": "./dist/geoarrow.es.mjs"
+    },
+    "./earcut.worker.js": "./dist/earcut.worker.js",
+    "./earcut.worker.min.js": "./dist/earcut.worker.min.js"
   },
   "publishConfig": {
     "access": "public"

--- a/worker-build.mjs
+++ b/worker-build.mjs
@@ -1,20 +1,37 @@
 // worker-build.mjs
 import esbuild from "esbuild";
 
-esbuild.build({
-  entryPoints: ["./src/worker-bundle/earcut.ts"],
-  outfile: "dist/earcut-worker.js",
-  bundle: true,
-  minify: false,
-  target: ["esnext"],
-  format: "esm",
-});
+// dist/earcut.worker.js was added to be easier for esbuild to consume, as it
+// allows loading as text via:
+// ```
+// loader: {
+//   ".worker.js": "text",
+//   ".worker.min.js": "text",
+// },
+// ```
+// We keep dist/earcut-worker.js for backwards compatibility.
+for (const outfile of ["dist/earcut-worker.js", "dist/earcut.worker.js"]) {
+  esbuild.build({
+    entryPoints: ["./src/worker-bundle/earcut.ts"],
+    outfile,
+    bundle: true,
+    minify: false,
+    target: ["esnext"],
+    format: "esm",
+  });
+}
 
-esbuild.build({
-  entryPoints: ["./src/worker-bundle/earcut.ts"],
-  outfile: "dist/earcut-worker.min.js",
-  bundle: true,
-  minify: true,
-  target: ["esnext"],
-  format: "esm",
-});
+// Likewise, earcut-worker.min.js is for backwards compatibility.
+for (const outfile of [
+  "dist/earcut-worker.min.js",
+  "dist/earcut.worker.min.js",
+]) {
+  esbuild.build({
+    entryPoints: ["./src/worker-bundle/earcut.ts"],
+    outfile,
+    bundle: true,
+    minify: true,
+    target: ["esnext"],
+    format: "esm",
+  });
+}


### PR DESCRIPTION
Allows esbuild to consume these as text with

```js
esbuild.build({
  ...,
  loader: {
    ".worker.js": "text",
    ".worker.min.js": "text",
  },
});
```