### PR TITLE
chore: Prepare 0.3.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## [0.3.2] - 2024-10-27
+## [0.3.3] - 2025-10-27
 
 - feat: Worker build improvements for earcut worker #39
+
+## [0.3.2] - 2025-02-10
+
+- Consolidate apache arrow imports by @danielfdsilva in #35
 
 ## [0.3.1] - 2024-06-25
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoarrow/geoarrow-js",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "TypeScript implementation of GeoArrow",
   "source": "src/index.ts",
   "umd:main": "dist/geoarrow.umd.js",


### PR DESCRIPTION
I went to release 0.3.2 and found it already had a tag and release 😅 