### PR TITLE
feat(wkb): add MultiPolygon support to WKB parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,13 @@
     "src/"
   ],
   "peerDependencies": {
+    "@loaders.gl/schema": "*",
+    "@loaders.gl/wkt": "*",
     "apache-arrow": ">=15"
   },
   "devDependencies": {
+    "@loaders.gl/schema": "^4.3.3",
+    "@loaders.gl/wkt": "^4.3.3",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.3",
     "@rollup/plugin-typescript": "^11.1.2",

--- a/src/algorithm/utils/assert.ts
+++ b/src/algorithm/utils/assert.ts
@@ -4,6 +4,6 @@ export function assert(condition: boolean, message?: string) {
   }
 }
 
-export function assertFalse(): never {
-  throw new Error(`assertion failed`);
+export function assertFalse(message?: string): never {
+  throw new Error(`assertion failed ${message}`);
 }

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,6 +1,7 @@
 import { Data } from "apache-arrow";
 import {
   WKB,
+  LargeWKB,
   Point,
   LineString,
   Polygon,
@@ -29,6 +30,7 @@ export type GeoArrowData =
   | MultiLineStringData
   | MultiPolygonData;
 export type WKBData = Data<WKB>;
+export type LargeWKBData = Data<LargeWKB>;
 
 export function isPointData(data: Data): data is PointData {
   return isPoint(data.type);

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,5 +1,6 @@
 import { Data } from "apache-arrow";
 import {
+  WKB,
   Point,
   LineString,
   Polygon,
@@ -27,6 +28,7 @@ export type GeoArrowData =
   | MultiPointData
   | MultiLineStringData
   | MultiPolygonData;
+export type WKBData = Data<WKB>;
 
 export function isPointData(data: Data): data is PointData {
   return isPoint(data.type);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * as data from "./data.js";
 export * as type from "./type.js";
 export * as vector from "./vector.js";
 export * as worker from "./worker";
+export * as io from "./io";

--- a/src/io/index.ts
+++ b/src/io/index.ts
@@ -1,0 +1,1 @@
+export { parseWkb, WKBType } from "./wkb.js";

--- a/src/io/wkb.test.ts
+++ b/src/io/wkb.test.ts
@@ -1,0 +1,152 @@
+import { describe, test, expect } from "vitest";
+import { makeData, Binary, Data, List } from "apache-arrow";
+import { parseWkb, WKBType } from "./wkb";
+
+function hexToUint8Array(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+function makeWkbData(...hexStrings: string[]) {
+  const buffers = hexStrings.map(hexToUint8Array);
+  const totalLen = buffers.reduce((s, b) => s + b.length, 0);
+  const wkb = new Uint8Array(totalLen);
+  const valueOffsets = new Int32Array(hexStrings.length + 1);
+  let offset = 0;
+  for (let i = 0; i < buffers.length; i++) {
+    wkb.set(buffers[i], offset);
+    offset += buffers[i].length;
+    valueOffsets[i + 1] = offset;
+  }
+  return makeData({
+    type: new Binary(),
+    data: wkb,
+    valueOffsets,
+  });
+}
+
+/** Extract offset arrays from nested List data for structural assertions */
+function getOffsets(data: Data<List>, level: number): Int32Array {
+  let d: Data = data;
+  for (let i = 0; i < level; i++) {
+    d = (d as Data<List>).children[0];
+  }
+  return (d as Data<List>).valueOffsets;
+}
+
+function getCoords(data: Data<List>, dim: number): number[][] {
+  let d: Data = data;
+  // walk: geom -> polygon -> ring -> vertex (FixedSizeList) -> Float64
+  while (d.children?.length) {
+    d = d.children[0];
+  }
+  const flat = d.values as Float64Array;
+  const coords: number[][] = [];
+  for (let i = 0; i < flat.length; i += dim) {
+    coords.push(Array.from(flat.slice(i, i + dim)));
+  }
+  return coords;
+}
+
+// Generated via shapely:
+// MultiPolygon([box(0,0,1,1), box(2,2,3,3)]).wkb_hex
+const TWO_SQUARES_HEX =
+  "01060000000200000001030000000100000005000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000000000000000F03F0000000000000000010300000001000000050000000000000000000840000000000000004000000000000008400000000000000840000000000000004000000000000008400000000000000040000000000000004000000000000008400000000000000040";
+
+// MultiPolygon([box(0,0,1,1)]).wkb_hex
+const SINGLE_POLYGON_HEX =
+  "01060000000100000001030000000100000005000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000000000000000F03F0000000000000000";
+
+// MultiPolygon([Polygon(box(0,0,10,10).exterior, [box(2,2,4,4).exterior])]).wkb_hex
+const WITH_HOLE_HEX =
+  "010600000001000000010300000002000000050000000000000000002440000000000000000000000000000024400000000000002440000000000000000000000000000024400000000000000000000000000000000000000000000024400000000000000000050000000000000000001040000000000000004000000000000010400000000000001040000000000000004000000000000010400000000000000040000000000000004000000000000010400000000000000040";
+
+describe("parseWkb MultiPolygon", () => {
+  test("two squares: structure and coordinates", () => {
+    const wkbData = makeWkbData(TWO_SQUARES_HEX);
+    const result = parseWkb(wkbData, WKBType.MultiPolygon, 2) as Data<List>;
+    expect(result.length).toBe(1);
+
+    // geom offsets: 1 multipolygon containing 2 polygons
+    const geomOffsets = result.valueOffsets;
+    expect(Array.from(geomOffsets)).toEqual([0, 2]);
+
+    // polygon offsets: 2 polygons, each with 1 ring
+    const polyOffsets = getOffsets(result, 1);
+    expect(Array.from(polyOffsets)).toEqual([0, 1, 2]);
+
+    // ring offsets: 2 rings, each with 5 coords (closed box)
+    const ringOffsets = getOffsets(result, 2);
+    expect(Array.from(ringOffsets)).toEqual([0, 5, 10]);
+
+    // verify coordinate values
+    const coords = getCoords(result, 2);
+    expect(coords.length).toBe(10);
+    // first polygon starts at (1,0) - shapely box winding
+    expect(coords[0]).toEqual([1, 0]);
+    // second polygon starts at (3,2)
+    expect(coords[5]).toEqual([3, 2]);
+  });
+
+  test("single polygon in multipolygon", () => {
+    const wkbData = makeWkbData(SINGLE_POLYGON_HEX);
+    const result = parseWkb(wkbData, WKBType.MultiPolygon, 2) as Data<List>;
+    expect(result.length).toBe(1);
+
+    const geomOffsets = result.valueOffsets;
+    expect(Array.from(geomOffsets)).toEqual([0, 1]);
+
+    const polyOffsets = getOffsets(result, 1);
+    expect(Array.from(polyOffsets)).toEqual([0, 1]);
+
+    const ringOffsets = getOffsets(result, 2);
+    expect(Array.from(ringOffsets)).toEqual([0, 5]);
+
+    expect(getCoords(result, 2).length).toBe(5);
+  });
+
+  test("polygon with hole: 2 rings", () => {
+    const wkbData = makeWkbData(WITH_HOLE_HEX);
+    const result = parseWkb(wkbData, WKBType.MultiPolygon, 2) as Data<List>;
+    expect(result.length).toBe(1);
+
+    // 1 multipolygon -> 1 polygon -> 2 rings (outer + hole)
+    const geomOffsets = result.valueOffsets;
+    expect(Array.from(geomOffsets)).toEqual([0, 1]);
+
+    const polyOffsets = getOffsets(result, 1);
+    expect(Array.from(polyOffsets)).toEqual([0, 2]);
+
+    const ringOffsets = getOffsets(result, 2);
+    expect(Array.from(ringOffsets)).toEqual([0, 5, 10]);
+
+    const coords = getCoords(result, 2);
+    expect(coords.length).toBe(10);
+    // outer ring starts at (10,0), hole starts at (4,2)
+    expect(coords[0]).toEqual([10, 0]);
+    expect(coords[5]).toEqual([4, 2]);
+  });
+
+  test("batch of multiple multipolygon features", () => {
+    const wkbData = makeWkbData(TWO_SQUARES_HEX, SINGLE_POLYGON_HEX);
+    const result = parseWkb(wkbData, WKBType.MultiPolygon, 2) as Data<List>;
+    expect(result.length).toBe(2);
+
+    // feature 0 has 2 polygons, feature 1 has 1 polygon
+    const geomOffsets = result.valueOffsets;
+    expect(Array.from(geomOffsets)).toEqual([0, 2, 3]);
+
+    // 3 polygons total, each with 1 ring
+    const polyOffsets = getOffsets(result, 1);
+    expect(Array.from(polyOffsets)).toEqual([0, 1, 2, 3]);
+
+    // 3 rings, each with 5 coords
+    const ringOffsets = getOffsets(result, 2);
+    expect(Array.from(ringOffsets)).toEqual([0, 5, 10, 15]);
+
+    expect(getCoords(result, 2).length).toBe(15);
+  });
+});

--- a/src/io/wkb.ts
+++ b/src/io/wkb.ts
@@ -1,0 +1,270 @@
+import { makeData } from "apache-arrow/data";
+import {
+  GeoArrowData,
+  LineStringData,
+  PointData,
+  PolygonData,
+  WKBData,
+} from "../data";
+import { WKBLoader } from "@loaders.gl/wkt";
+import type {
+  BinaryGeometry,
+  BinaryPointGeometry,
+  BinaryLineGeometry,
+  BinaryPolygonGeometry,
+} from "@loaders.gl/schema";
+import { assert, assertFalse } from "../algorithm/utils/assert";
+import { Field, FixedSizeList, Float64, List } from "apache-arrow";
+
+export enum WKBType {
+  Point,
+  LineString,
+  Polygon,
+  MultiPoint,
+  MultiLineString,
+  MultiPolygon,
+}
+
+/**
+ * Parse an Arrow array of WKB
+ *
+ * @return  {[type]}  [return description]
+ */
+export function parseWkb(
+  data: WKBData,
+  type: WKBType,
+  dim: number,
+): GeoArrowData {
+  const parsedGeometries: BinaryGeometry[] = [];
+
+  for (const item of iterBinary(data)) {
+    if (item === null) {
+      throw new Error("Null entries are not currently supported");
+    }
+    const arrayBuffer = copyViewToArrayBuffer(item);
+    const parsed = WKBLoader.parseSync(arrayBuffer, {
+      wkb: { shape: "binary-geometry" },
+    }) as BinaryGeometry;
+    parsedGeometries.push(parsed);
+  }
+
+  switch (type) {
+    case WKBType.Point:
+      return repackPoints(parsedGeometries as BinaryPointGeometry[], dim);
+
+    case WKBType.LineString:
+      return repackLineStrings(parsedGeometries as BinaryLineGeometry[], dim);
+
+    case WKBType.Polygon:
+      return repackPolygons(parsedGeometries as BinaryPolygonGeometry[], dim);
+
+    default:
+      assertFalse("Not yet implemented for this geometry type");
+  }
+}
+
+function* iterBinary(data: WKBData): IterableIterator<Uint8Array | null> {
+  const values = data.values;
+  const valueOffsets = data.valueOffsets;
+  for (let i = 0; i < data.length; i++) {
+    if (!data.getValid(i)) {
+      yield null;
+    } else {
+      const startOffset = valueOffsets[i];
+      const endOffset = valueOffsets[i + 1];
+      yield values.subarray(startOffset, endOffset);
+    }
+  }
+}
+
+// TODO: update loaders.gl parseWKB to accept Uint8Array, not just ArrayBuffer.
+function copyViewToArrayBuffer(view: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(view.byteLength);
+  new Uint8Array(buffer).set(view);
+  return buffer;
+}
+
+function repackPoints(geoms: BinaryPointGeometry[], dim: number): PointData {
+  const geomLength = geoms.length;
+  const coords = new Float64Array(geomLength * dim);
+  let coordOffset = 0;
+  for (const geom of geoms) {
+    assert(geom.positions.value instanceof Float64Array);
+    coords.set(geom.positions.value, coordOffset * dim);
+    coordOffset += 1;
+  }
+
+  const coordsData = makeData({
+    type: new Float64(),
+    data: coords,
+  });
+  return makeData({
+    type: new FixedSizeList(
+      dim,
+      new Field(coordFieldName(dim), new Float64(), false),
+    ),
+    child: coordsData,
+  });
+}
+
+type LineStringCapacity = {
+  coordCapacty: number;
+  geomCapacity: number;
+};
+
+function repackLineStrings(
+  geoms: BinaryLineGeometry[],
+  dim: number,
+): LineStringData {
+  const capacity = inferLineStringCapacity(geoms);
+  const coords = new Float64Array(capacity.coordCapacty * dim);
+  const geomOffsets = new Int32Array(capacity.geomCapacity + 1);
+
+  let geomIndex = 0;
+  let coordOffset = 0;
+  for (const geom of geoms) {
+    assert(geom.positions.value instanceof Float64Array);
+    const numCoords = geom.positions.value.length / geom.positions.size;
+    coords.set(geom.positions.value, coordOffset * dim);
+    geomIndex += 1;
+    coordOffset += numCoords;
+
+    // Note this is after we've added one
+    geomOffsets[geomIndex] = coordOffset;
+  }
+
+  const coordsData = makeData({
+    type: new Float64(),
+    data: coords,
+  });
+  const verticesData = makeData({
+    type: new FixedSizeList(
+      dim,
+      new Field(coordFieldName(dim), coordsData.type, false),
+    ),
+    child: coordsData,
+  });
+  return makeData({
+    type: new List(new Field("vertices", verticesData.type, false)),
+    valueOffsets: geomOffsets,
+    child: verticesData,
+  });
+}
+
+function inferLineStringCapacity(
+  geoms: BinaryLineGeometry[],
+): LineStringCapacity {
+  let capacity: LineStringCapacity = {
+    coordCapacty: 0,
+    geomCapacity: 0,
+  };
+
+  // TODO: check geom.pathIndices to validate that we have a LineString and not
+  // a multi line string
+  for (const geom of geoms) {
+    capacity.geomCapacity += 1;
+    capacity.coordCapacty += geom.positions.value.length / geom.positions.size;
+  }
+
+  return capacity;
+}
+
+type PolygonCapacity = {
+  coordCapacty: number;
+  /** This is what loaders.gl calls `primitivePolygonIndices` */
+  ringCapacity: number;
+  geomCapacity: number;
+};
+
+function repackPolygons(
+  geoms: BinaryPolygonGeometry[],
+  dim: number,
+): PolygonData {
+  const capacity = inferPolygonCapacity(geoms);
+  const coords = new Float64Array(capacity.coordCapacty * dim);
+  const ringOffsets = new Int32Array(capacity.ringCapacity + 1);
+  const geomOffsets = new Int32Array(capacity.geomCapacity + 1);
+
+  let geomIndex = 0;
+  let coordOffset = 0;
+  let ringOffset = 0;
+
+  for (const geom of geoms) {
+    assert(geom.positions.value instanceof Float64Array);
+    const numCoords = geom.positions.value.length / geom.positions.size;
+
+    coords.set(geom.positions.value, coordOffset * dim);
+    coordOffset += numCoords;
+
+    for (
+      let ringIdx = 0;
+      ringIdx < geom.primitivePolygonIndices.value.length - 1;
+      ringIdx++
+    ) {
+      ringOffsets[ringOffset + 1] =
+        (geom.primitivePolygonIndices.value[ringOffset + 1] -
+          geom.primitivePolygonIndices.value[ringOffset]) /
+        geom.positions.size;
+      ringOffset += 1;
+    }
+
+    geomOffsets[geomIndex + 1] = ringOffset;
+    geomIndex += 1;
+  }
+
+  const coordsData = makeData({
+    type: new Float64(),
+    data: coords,
+  });
+  const verticesData = makeData({
+    type: new FixedSizeList(
+      dim,
+      new Field(coordFieldName(dim), coordsData.type, false),
+    ),
+    child: coordsData,
+  });
+
+  const ringsData = makeData({
+    type: new List(new Field("vertices", verticesData.type, false)),
+    valueOffsets: ringOffsets,
+    child: verticesData,
+  });
+
+  return makeData({
+    type: new List(new Field("rings", ringsData.type, false)),
+    valueOffsets: geomOffsets,
+    child: ringsData,
+  });
+}
+
+function inferPolygonCapacity(geoms: BinaryPolygonGeometry[]): PolygonCapacity {
+  let capacity: PolygonCapacity = {
+    coordCapacty: 0,
+    ringCapacity: 0,
+    geomCapacity: 0,
+  };
+
+  // TODO: check geom.polygonIndices to validate that we have a Polygon and not
+  // a MultiPolygon
+  for (const geom of geoms) {
+    capacity.geomCapacity += 1;
+    assert(
+      geom.primitivePolygonIndices.value.length >= 1,
+      "Expected primitivePolygonIndices to always have length at least 1",
+    );
+    capacity.ringCapacity += geom.primitivePolygonIndices.value.length - 1;
+    capacity.coordCapacty += geom.positions.value.length / geom.positions.size;
+  }
+
+  return capacity;
+}
+
+function coordFieldName(dim: number): "xy" | "xyz" {
+  if (dim === 2) {
+    return "xy";
+  } else if (dim === 3) {
+    return "xyz";
+  } else {
+    assertFalse("expected dimension of 2 or 3");
+  }
+}

--- a/src/io/wkb.ts
+++ b/src/io/wkb.ts
@@ -14,7 +14,9 @@ import type {
   BinaryPolygonGeometry,
 } from "@loaders.gl/schema";
 import { assert, assertFalse } from "../algorithm/utils/assert";
-import { Field, FixedSizeList, Float64, List } from "apache-arrow";
+import { FixedSizeList, Float64, List } from "apache-arrow/type";
+import { Field } from "apache-arrow/schema";
+
 
 export enum WKBType {
   Point,
@@ -36,6 +38,7 @@ export function parseWkb(
   dim: number,
 ): GeoArrowData {
   const parsedGeometries: BinaryGeometry[] = [];
+
 
   for (const item of iterBinary(data)) {
     if (item === null) {

--- a/src/io/wkb.ts
+++ b/src/io/wkb.ts
@@ -1,4 +1,4 @@
-import { makeData } from "apache-arrow/data";
+import { makeData, Field, FixedSizeList, Float64, List } from "apache-arrow";
 import {
   GeoArrowData,
   LineStringData,
@@ -14,9 +14,6 @@ import type {
   BinaryPolygonGeometry,
 } from "@loaders.gl/schema";
 import { assert, assertFalse } from "../algorithm/utils/assert";
-import { FixedSizeList, Float64, List } from "apache-arrow/type";
-import { Field } from "apache-arrow/schema";
-
 
 export enum WKBType {
   Point,
@@ -38,7 +35,6 @@ export function parseWkb(
   dim: number,
 ): GeoArrowData {
   const parsedGeometries: BinaryGeometry[] = [];
-
 
   for (const item of iterBinary(data)) {
     if (item === null) {

--- a/src/io/wkb.ts
+++ b/src/io/wkb.ts
@@ -201,9 +201,9 @@ function repackPolygons(
       ringIdx++
     ) {
       ringOffsets[ringOffset + 1] =
-        (geom.primitivePolygonIndices.value[ringOffset + 1] -
-          geom.primitivePolygonIndices.value[ringOffset]) /
-        geom.positions.size;
+        ringOffsets[ringOffset] +
+        (geom.primitivePolygonIndices.value[ringIdx + 1] -
+          geom.primitivePolygonIndices.value[ringIdx]);
       ringOffset += 1;
     }
 

--- a/src/io/wkb.ts
+++ b/src/io/wkb.ts
@@ -2,6 +2,7 @@ import { makeData, Field, FixedSizeList, Float64, List } from "apache-arrow";
 import {
   GeoArrowData,
   LineStringData,
+  MultiPolygonData,
   PointData,
   PolygonData,
   WKBData,
@@ -56,6 +57,12 @@ export function parseWkb(
 
     case WKBType.Polygon:
       return repackPolygons(parsedGeometries as BinaryPolygonGeometry[], dim);
+
+    case WKBType.MultiPolygon:
+      return repackMultiPolygons(
+        parsedGeometries as BinaryPolygonGeometry[],
+        dim,
+      );
 
     default:
       assertFalse("Not yet implemented for this geometry type");
@@ -253,6 +260,121 @@ function inferPolygonCapacity(geoms: BinaryPolygonGeometry[]): PolygonCapacity {
     );
     capacity.ringCapacity += geom.primitivePolygonIndices.value.length - 1;
     capacity.coordCapacty += geom.positions.value.length / geom.positions.size;
+  }
+
+  return capacity;
+}
+
+type MultiPolygonCapacity = {
+  coordCapacity: number;
+  ringCapacity: number;
+  polygonCapacity: number;
+  geomCapacity: number;
+};
+
+function repackMultiPolygons(
+  geoms: BinaryPolygonGeometry[],
+  dim: number,
+): MultiPolygonData {
+  const capacity = inferMultiPolygonCapacity(geoms);
+  const coords = new Float64Array(capacity.coordCapacity * dim);
+  const ringOffsets = new Int32Array(capacity.ringCapacity + 1);
+  const polygonOffsets = new Int32Array(capacity.polygonCapacity + 1);
+  const geomOffsets = new Int32Array(capacity.geomCapacity + 1);
+
+  let geomIndex = 0;
+  let polygonIndex = 0;
+  let ringIndex = 0;
+  let coordOffset = 0;
+
+  for (const geom of geoms) {
+    assert(geom.positions.value instanceof Float64Array);
+    const numCoords = geom.positions.value.length / geom.positions.size;
+
+    coords.set(geom.positions.value, coordOffset * dim);
+
+    // polygonIndices uses coordinate indices (not ring indices) to separate
+    // component polygons. We scan primitivePolygonIndices to find which rings
+    // belong to each polygon.
+    const primIndices = geom.primitivePolygonIndices.value;
+    const polyCoordIndices =
+      geom.polygonIndices?.value ?? new Int32Array([0, numCoords]);
+    const numPolygons = polyCoordIndices.length - 1;
+    let ringPtr = 0;
+
+    for (let p = 0; p < numPolygons; p++) {
+      const polyCoordEnd = polyCoordIndices[p + 1];
+
+      // Assign rings to this polygon: a ring belongs here if its start
+      // coordinate index falls before the polygon's end coordinate index.
+      while (
+        ringPtr < primIndices.length - 1 &&
+        primIndices[ringPtr] < polyCoordEnd
+      ) {
+        ringOffsets[ringIndex + 1] =
+          ringOffsets[ringIndex] +
+          (primIndices[ringPtr + 1] - primIndices[ringPtr]);
+        ringIndex += 1;
+        ringPtr += 1;
+      }
+
+      polygonOffsets[polygonIndex + 1] = ringIndex;
+      polygonIndex += 1;
+    }
+
+    coordOffset += numCoords;
+    geomOffsets[geomIndex + 1] = polygonIndex;
+    geomIndex += 1;
+  }
+
+  const coordsData = makeData({
+    type: new Float64(),
+    data: coords,
+  });
+  const verticesData = makeData({
+    type: new FixedSizeList(
+      dim,
+      new Field(coordFieldName(dim), coordsData.type, false),
+    ),
+    child: coordsData,
+  });
+  const ringsData = makeData({
+    type: new List(new Field("vertices", verticesData.type, false)),
+    valueOffsets: ringOffsets,
+    child: verticesData,
+  });
+  const polygonsData = makeData({
+    type: new List(new Field("rings", ringsData.type, false)),
+    valueOffsets: polygonOffsets,
+    child: ringsData,
+  });
+  return makeData({
+    type: new List(new Field("polygons", polygonsData.type, false)),
+    valueOffsets: geomOffsets,
+    child: polygonsData,
+  });
+}
+
+function inferMultiPolygonCapacity(
+  geoms: BinaryPolygonGeometry[],
+): MultiPolygonCapacity {
+  let capacity: MultiPolygonCapacity = {
+    coordCapacity: 0,
+    ringCapacity: 0,
+    polygonCapacity: 0,
+    geomCapacity: 0,
+  };
+
+  for (const geom of geoms) {
+    capacity.geomCapacity += 1;
+    const polyIndices = geom.polygonIndices?.value;
+    if (polyIndices) {
+      capacity.polygonCapacity += polyIndices.length - 1;
+    } else {
+      capacity.polygonCapacity += 1;
+    }
+    capacity.ringCapacity += geom.primitivePolygonIndices.value.length - 1;
+    capacity.coordCapacity += geom.positions.value.length / geom.positions.size;
   }
 
   return capacity;

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,5 +1,6 @@
 import {
   type Binary,
+  type LargeBinary,
   type Struct,
   type Float,
   type List,
@@ -31,6 +32,7 @@ export type GeoArrowType =
   | MultiLineString
   | MultiPolygon;
 export type WKB = Binary;
+export type LargeWKB = LargeBinary;
 
 /** Check that the given type is a Point data type */
 export function isPoint(type: DataType): type is Point {

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,5 @@
 import {
+  Binary,
   type Struct,
   type Float,
   type List,
@@ -29,6 +30,7 @@ export type GeoArrowType =
   | MultiPoint
   | MultiLineString
   | MultiPolygon;
+export type WKB = Binary;
 
 /** Check that the given type is a Point data type */
 export function isPoint(type: DataType): type is Point {

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,5 +1,5 @@
 import {
-  Binary,
+  type Binary,
   type Struct,
   type Float,
   type List,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "strictNullChecks": true,
+    "skipLibCheck": true,
     "lib": ["es2019.array", "es6", "dom"]
   },
   "include": ["./src/**/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -226,6 +226,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@geoarrow/geoarrow-js@workspace:."
   dependencies:
+    "@loaders.gl/schema": "npm:^4.3.3"
+    "@loaders.gl/wkt": "npm:^4.3.3"
     "@math.gl/polygon": "npm:^4.0.0"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@rollup/plugin-terser": "npm:^0.4.3"
@@ -246,6 +248,8 @@ __metadata:
     typescript: "npm:^5.2.2"
     vitest: "npm:^0.34.6"
   peerDependencies:
+    "@loaders.gl/schema": "*"
+    "@loaders.gl/wkt": "*"
     apache-arrow: ">=15"
   languageName: unknown
   linkType: soft
@@ -335,6 +339,84 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@loaders.gl/gis@npm:4.3.3":
+  version: 4.3.3
+  resolution: "@loaders.gl/gis@npm:4.3.3"
+  dependencies:
+    "@loaders.gl/loader-utils": "npm:4.3.3"
+    "@loaders.gl/schema": "npm:4.3.3"
+    "@mapbox/vector-tile": "npm:^1.3.1"
+    "@math.gl/polygon": "npm:^4.1.0"
+    pbf: "npm:^3.2.1"
+  peerDependencies:
+    "@loaders.gl/core": ^4.3.0
+  checksum: 35ee958d164e894c510dd43caaf630f6007568bc36523a2c2e2744c86e8008e039c542d3693d6655fc7db3b510058e8984da01fbb15b905f5c6e299830cb1c13
+  languageName: node
+  linkType: hard
+
+"@loaders.gl/loader-utils@npm:4.3.3":
+  version: 4.3.3
+  resolution: "@loaders.gl/loader-utils@npm:4.3.3"
+  dependencies:
+    "@loaders.gl/schema": "npm:4.3.3"
+    "@loaders.gl/worker-utils": "npm:4.3.3"
+    "@probe.gl/log": "npm:^4.0.2"
+    "@probe.gl/stats": "npm:^4.0.2"
+  peerDependencies:
+    "@loaders.gl/core": ^4.3.0
+  checksum: b95417430528af7e2fda748406643d2f5e709fd05216b4959d774e4a12fff56155bed28cc1847e1af2761070954367a3eed8f5ebe5ca4c13f26a7cedc30de1e0
+  languageName: node
+  linkType: hard
+
+"@loaders.gl/schema@npm:4.3.3, @loaders.gl/schema@npm:^4.3.3":
+  version: 4.3.3
+  resolution: "@loaders.gl/schema@npm:4.3.3"
+  dependencies:
+    "@types/geojson": "npm:^7946.0.7"
+  peerDependencies:
+    "@loaders.gl/core": ^4.3.0
+  checksum: a04888ec04d0f44aed72c5c4130df6a7aca6cb872cffcc5616f79478d808789580a3292c8fa778761f99f45b1581224a62095c20f690a57782f24124e685520e
+  languageName: node
+  linkType: hard
+
+"@loaders.gl/wkt@npm:^4.3.3":
+  version: 4.3.3
+  resolution: "@loaders.gl/wkt@npm:4.3.3"
+  dependencies:
+    "@loaders.gl/gis": "npm:4.3.3"
+    "@loaders.gl/loader-utils": "npm:4.3.3"
+    "@loaders.gl/schema": "npm:4.3.3"
+  peerDependencies:
+    "@loaders.gl/core": ^4.3.0
+  checksum: 9fd227b72b41811bc18775147f96069b5a6036e830826a3b3378c635415a41e733ff866ee627bc48771e3c08303c354ea23ac5e8c0a6a35dbd712fc1e769034e
+  languageName: node
+  linkType: hard
+
+"@loaders.gl/worker-utils@npm:4.3.3":
+  version: 4.3.3
+  resolution: "@loaders.gl/worker-utils@npm:4.3.3"
+  peerDependencies:
+    "@loaders.gl/core": ^4.3.0
+  checksum: e0fea94518a226ee2ecbcf40ae76eab2c0b6fdca3dc596b03b9febc11f0d66cec1c5c3d1c6908f47f87b3b950f2a4b3ad04be4012e26119ce838953bff37a2e7
+  languageName: node
+  linkType: hard
+
+"@mapbox/point-geometry@npm:~0.1.0":
+  version: 0.1.0
+  resolution: "@mapbox/point-geometry@npm:0.1.0"
+  checksum: f6f78ac8a7f798efb19db6eb1a9e05da7ba942102f5347c1a673d94202d0c606ec3f522efa3e76d583cdca46fb96dde52c3d37234f162d21df42f9e8c4f182bd
+  languageName: node
+  linkType: hard
+
+"@mapbox/vector-tile@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@mapbox/vector-tile@npm:1.3.1"
+  dependencies:
+    "@mapbox/point-geometry": "npm:~0.1.0"
+  checksum: ed31eeef0d593befde76b5b4edf0472709a2ba66dd6b32fad5671caa245fdac976e23ff385facf36e297f14a53c905bfde8911599e8aa690354d52b22bc4cfc5
+  languageName: node
+  linkType: hard
+
 "@math.gl/core@npm:4.0.0":
   version: 4.0.0
   resolution: "@math.gl/core@npm:4.0.0"
@@ -342,6 +424,15 @@ __metadata:
     "@babel/runtime": "npm:^7.12.0"
     "@math.gl/types": "npm:4.0.0"
   checksum: 8208e9d917d3b8b90db1546b3dd69512a26556a832d95f23580909bf76349ee83debf95db974528254f7bed2ad36c25a0457c73b9d208b51f866a88304b6ac8c
+  languageName: node
+  linkType: hard
+
+"@math.gl/core@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@math.gl/core@npm:4.1.0"
+  dependencies:
+    "@math.gl/types": "npm:4.1.0"
+  checksum: 4b4c1c4cd08df24687e90469f2e17ad4db9547df58e45585a1f91fb9590b6f96ef3287fbc7f4b9aabc9531d4c223748354a3633ea0ed354c3ff96e11243f19f9
   languageName: node
   linkType: hard
 
@@ -354,10 +445,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@math.gl/polygon@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@math.gl/polygon@npm:4.1.0"
+  dependencies:
+    "@math.gl/core": "npm:4.1.0"
+  checksum: ea2b2f9ec9772f04b9f57691d472374d149960287deb33f91a87e28aafa81a95a3ff1101bc59d51be47a2aade79275e7fe0df6b4cd8d04a06c652ea93365efbc
+  languageName: node
+  linkType: hard
+
 "@math.gl/types@npm:4.0.0":
   version: 4.0.0
   resolution: "@math.gl/types@npm:4.0.0"
   checksum: 8fce7215bf7b9c48c09026fcd41f86b5c118afa3580a937831198f82324e468aa9aec53942bf7aa848f9782f2142225b891a0eb8e403f7b8cec669308272147b
+  languageName: node
+  linkType: hard
+
+"@math.gl/types@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@math.gl/types@npm:4.1.0"
+  checksum: 55ae7f4e2b89832c417a59cfb93f3a1fe37fda89d84678562a06fbae19e082e6e4147383963b7e67d8507bc5979c9347b7ce7598ec8daca4c4fee48ae00cbece
   languageName: node
   linkType: hard
 
@@ -387,6 +494,29 @@ __metadata:
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
   checksum: 115e8ceeec6bc69dff2048b35c0ab4f8bbee12d8bb6c1f4af758604586d802b6e669dcb02dda61d078de42c2b4ddce41b3d9e726d7daa6b4b850f4adbf7333ff
+  languageName: node
+  linkType: hard
+
+"@probe.gl/env@npm:4.0.9":
+  version: 4.0.9
+  resolution: "@probe.gl/env@npm:4.0.9"
+  checksum: ea8a98619375f53867f0d5bdf0f59b89f9862c4185a9c742f922278d5eeb78578ec4a3a2d729aa3a1c9cafa167fbc3981bc03dc3034a40bd4ade6491ffad4f3b
+  languageName: node
+  linkType: hard
+
+"@probe.gl/log@npm:^4.0.2":
+  version: 4.0.9
+  resolution: "@probe.gl/log@npm:4.0.9"
+  dependencies:
+    "@probe.gl/env": "npm:4.0.9"
+  checksum: 650667b35cf075507c23725b1dcda8bf4fb5d562bcdc6fa6305defa221aefeca3a1975cd893db0367a45a8419418f258e6becc6c7f33430b7fa48a78c9b28cd9
+  languageName: node
+  linkType: hard
+
+"@probe.gl/stats@npm:^4.0.2":
+  version: 4.0.9
+  resolution: "@probe.gl/stats@npm:4.0.9"
+  checksum: 61c31bdc523952e65561f3be3ef34f537c94593cafa95124fd25540a06046d6b14076c8d539806ee53f24101cf8b6e3fd461b4d1d2aee266ec915642c787b379
   languageName: node
   linkType: hard
 
@@ -629,6 +759,13 @@ __metadata:
   version: 1.0.5
   resolution: "@types/estree@npm:1.0.5"
   checksum: 7de6d928dd4010b0e20c6919e1a6c27b61f8d4567befa89252055fad503d587ecb9a1e3eab1b1901f923964d7019796db810b7fd6430acb26c32866d126fd408
+  languageName: node
+  linkType: hard
+
+"@types/geojson@npm:^7946.0.7":
+  version: 7946.0.15
+  resolution: "@types/geojson@npm:7946.0.15"
+  checksum: 226d7ab59540632b19f7889c76c4c586a5104c18c43a81f32974aa035eafe557f86bd5a79ca5568bb63cbe5bfa9014c8e9a29cb0bb3d2f0bd71b0cc13ad8ccb3
   languageName: node
   linkType: hard
 
@@ -1578,6 +1715,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ieee754@npm:^1.1.12":
+  version: 1.2.1
+  resolution: "ieee754@npm:1.2.1"
+  checksum: d9f2557a59036f16c282aaeb107832dc957a93d73397d89bbad4eb1130560560eb695060145e8e6b3b498b15ab95510226649a0b8f52ae06583575419fe10fc4
+  languageName: node
+  linkType: hard
+
 "imurmurhash@npm:^0.1.4":
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
@@ -2150,6 +2294,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pbf@npm:^3.2.1":
+  version: 3.3.0
+  resolution: "pbf@npm:3.3.0"
+  dependencies:
+    ieee754: "npm:^1.1.12"
+    resolve-protobuf-schema: "npm:^2.1.0"
+  bin:
+    pbf: bin/pbf
+  checksum: 46488694528740097c33443efa240ca7f99538a2b96e9fbd2284d9be45ec91dab6954b9c03df237656ac2757d7f046153a031ad24519b4cfcaa2e7b18ddeb5dd
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.0.0":
   version: 1.0.0
   resolution: "picocolors@npm:1.0.0"
@@ -2265,6 +2421,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"protocol-buffers-schema@npm:^3.3.1":
+  version: 3.6.0
+  resolution: "protocol-buffers-schema@npm:3.6.0"
+  checksum: 55a1caed123fb2385eae5ea4770dc36b3017d1fe2005ffb1ef20c97dadf43a91876238ebc23bc240ef1f8501d054bdd9d12992796e9abed18ddf958e4f942eea
+  languageName: node
+  linkType: hard
+
 "randombytes@npm:^2.1.0":
   version: 2.1.0
   resolution: "randombytes@npm:2.1.0"
@@ -2285,6 +2448,15 @@ __metadata:
   version: 0.14.1
   resolution: "regenerator-runtime@npm:0.14.1"
   checksum: 5db3161abb311eef8c45bcf6565f4f378f785900ed3945acf740a9888c792f75b98ecb77f0775f3bf95502ff423529d23e94f41d80c8256e8fa05ed4b07cf471
+  languageName: node
+  linkType: hard
+
+"resolve-protobuf-schema@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "resolve-protobuf-schema@npm:2.1.0"
+  dependencies:
+    protocol-buffers-schema: "npm:^3.3.1"
+  checksum: 88fffab2a3757888884a36f9aa4e24be5186b01820a8c26297dc1ce406b9daf776594926bdf524c2c8e8e5b0aba8ac48362b6584cdecc9a7083215ebca01c599
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds `WKBType.MultiPolygon` case to `parseWkb()`. Based on the WKB parser from the `kyle/wkb` branch, adding one more nesting level for geom-to-polygon offsets using `polygonIndices` from loaders.gl's `BinaryPolygonGeometry`.

MultiPolygon is a core OGC Simple Features type. The types (`MultiPolygonData`, `WKBType.MultiPolygon`) and type guards already exist in this library, only the `parseWkb()` case was missing.

## Changes

| File | Change |
|------|--------|
| `src/io/wkb.ts` | `repackMultiPolygons()` + `inferMultiPolygonCapacity()` |
| `src/io/wkb.test.ts` | 4 tests: two-polygon, single-polygon, with-hole, multi-feature batch |
| `src/type.ts`, `src/data.ts` | `LargeWKB` / `LargeWKBData` type aliases |

Tests verify offset arrays at every nesting level and spot-check coordinate values. WKB hex generated via Shapely. All 8 tests pass (4 new + 4 existing).

## Note

Based on `kyle/wkb`. stac-map depends on [smohiudd/geoarrow-js](https://github.com/smohiudd/geoarrow-js) (a fork of that branch) because it was never merged upstream.

*AI (Claude) supported my development of this PR.*